### PR TITLE
Add AMD ROCm/HIP acceleration on Linux

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -105,16 +105,55 @@ if [ ! -d "$HELPER_DIR" ]; then
 fi
 
 # Determine llama-helper features
-# Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
-# So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
+# Note: llama-cpp-2 supports neither coreml (use metal instead) nor the
+# `hipblas` name the Tauri transcription crate uses for AMD HIP (use `rocm`).
 HELPER_FEATURES=""
 if [ -n "$TAURI_GPU_FEATURE" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+    elif [ "$LLAMA_FEATURE" = "hipblas" ]; then
+        LLAMA_FEATURE="rocm"
+        echo -e "${YELLOW}   Note: llama-cpp-2 uses the ROCm feature for HIP acceleration${NC}"
     fi
     HELPER_FEATURES="--features $LLAMA_FEATURE"
+fi
+
+if [ "$TAURI_GPU_FEATURE" = "hipblas" ] && [ -z "$ROCM_PATH" ] && [ -z "$HIP_PATH" ]; then
+    for candidate in /opt/rocm /usr/local/rocm /usr/lib64/rocm /usr/lib/rocm; do
+        if [ -d "$candidate/lib" ]; then
+            export ROCM_PATH="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ "$TAURI_GPU_FEATURE" = "hipblas" ]; then
+    if [ -n "$ROCM_PATH" ]; then
+        echo -e "   Using ROCm SDK at $ROCM_PATH"
+    elif [ -n "$HIP_PATH" ]; then
+        echo -e "   Using HIP SDK at $HIP_PATH"
+    else
+        echo -e "${RED}❌ ROCm SDK not found; set ROCM_PATH or HIP_PATH${NC}"
+        exit 1
+    fi
+
+    # Fedora keeps ROCm's CMake package in /usr/lib64/cmake while the
+    # compiler and libraries live below /usr/lib64/rocm.
+    SDK_PATH="${ROCM_PATH:-$HIP_PATH}"
+    if [ -z "$CMAKE_HIP_COMPILER_ROCM_ROOT" ] && [ -f "$SDK_PATH/lib/cmake/hip-lang/hip-lang-config.cmake" ]; then
+        export CMAKE_HIP_COMPILER_ROCM_ROOT="$SDK_PATH"
+    elif [ -z "$CMAKE_HIP_COMPILER_ROCM_ROOT" ]; then
+        SDK_PARENT="$(dirname "$(dirname "$SDK_PATH")")"
+        if [ -f "$SDK_PARENT/lib64/cmake/hip-lang/hip-lang-config.cmake" ]; then
+            export CMAKE_HIP_COMPILER_ROCM_ROOT="$SDK_PARENT"
+        fi
+    fi
+
+    if [ -n "$CMAKE_HIP_COMPILER_ROCM_ROOT" ]; then
+        echo -e "   Using HIP CMake root at $CMAKE_HIP_COMPILER_ROCM_ROOT"
+    fi
 fi
 
 echo -e "   Building in $HELPER_DIR with features: ${HELPER_FEATURES:-none}"

--- a/frontend/dev-gpu.sh
+++ b/frontend/dev-gpu.sh
@@ -97,16 +97,53 @@ if [ ! -d "$HELPER_DIR" ]; then
 fi
 
 # Determine llama-helper features
-# Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
-# So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
+# Note: llama-cpp-2 supports neither coreml (use metal instead) nor the
+# `hipblas` name the Tauri transcription crate uses for AMD HIP (use `rocm`).
 HELPER_FEATURES=""
 if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+    elif [ "$LLAMA_FEATURE" = "hipblas" ]; then
+        LLAMA_FEATURE="rocm"
+        echo -e "${YELLOW}   Note: llama-cpp-2 uses the ROCm feature for HIP acceleration${NC}"
     fi
     HELPER_FEATURES="--features $LLAMA_FEATURE"
+fi
+
+if [ "$TAURI_GPU_FEATURE" = "hipblas" ] && [ -z "$ROCM_PATH" ] && [ -z "$HIP_PATH" ]; then
+    for candidate in /opt/rocm /usr/local/rocm /usr/lib64/rocm /usr/lib/rocm; do
+        if [ -d "$candidate/lib" ]; then
+            export ROCM_PATH="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ "$TAURI_GPU_FEATURE" = "hipblas" ]; then
+    if [ -n "$ROCM_PATH" ]; then
+        echo -e "   Using ROCm SDK at $ROCM_PATH"
+    elif [ -n "$HIP_PATH" ]; then
+        echo -e "   Using HIP SDK at $HIP_PATH"
+    else
+        echo -e "${RED}❌ ROCm SDK not found; set ROCM_PATH or HIP_PATH${NC}"
+        exit 1
+    fi
+
+    SDK_PATH="${ROCM_PATH:-$HIP_PATH}"
+    if [ -z "$CMAKE_HIP_COMPILER_ROCM_ROOT" ] && [ -f "$SDK_PATH/lib/cmake/hip-lang/hip-lang-config.cmake" ]; then
+        export CMAKE_HIP_COMPILER_ROCM_ROOT="$SDK_PATH"
+    elif [ -z "$CMAKE_HIP_COMPILER_ROCM_ROOT" ]; then
+        SDK_PARENT="$(dirname "$(dirname "$SDK_PATH")")"
+        if [ -f "$SDK_PARENT/lib64/cmake/hip-lang/hip-lang-config.cmake" ]; then
+            export CMAKE_HIP_COMPILER_ROCM_ROOT="$SDK_PARENT"
+        fi
+    fi
+
+    if [ -n "$CMAKE_HIP_COMPILER_ROCM_ROOT" ]; then
+        echo -e "   Using HIP CMake root at $CMAKE_HIP_COMPILER_ROCM_ROOT"
+    fi
 fi
 
 echo -e "   Building in $HELPER_DIR with features: ${HELPER_FEATURES:-none}"

--- a/frontend/scripts/auto-detect-gpu.js
+++ b/frontend/scripts/auto-detect-gpu.js
@@ -45,8 +45,12 @@ function detectGPU() {
       }
     }
 
-    // Check for AMD GPU (Linux only)
-    if (platform === 'linux' && commandExists('rocm-smi')) {
+    // Check for AMD GPU (Linux only). Fedora and newer ROCm installs may
+    // provide rocminfo without the legacy rocm-smi command.
+    if (
+      platform === 'linux' &&
+      (commandExists('rocm-smi') || commandExists('rocminfo'))
+    ) {
       const rocmPath = process.env.ROCM_PATH;
       if (rocmPath || commandExists('hipcc')) {
         console.log('🔴 AMD GPU detected with ROCm - using HIPBlas acceleration');

--- a/frontend/scripts/tauri-auto.js
+++ b/frontend/scripts/tauri-auto.js
@@ -40,13 +40,51 @@ console.log(''); // Empty line for spacing
 const platform = os.platform();
 const env = { ...process.env };
 
+if (platform === 'linux' && feature === 'hipblas') {
+  // llama-cpp-sys requires ROCM_PATH/HIP_PATH to point to a directory
+  // containing lib/. Fedora commonly installs ROCm under /usr/lib64/rocm.
+  if (!env.ROCM_PATH && !env.HIP_PATH) {
+    const candidates = ['/opt/rocm', '/usr/local/rocm', '/usr/lib64/rocm', '/usr/lib/rocm'];
+    const rocmPath = candidates.find((candidate) =>
+      fs.existsSync(path.join(candidate, 'lib'))
+    );
+    if (rocmPath) {
+      env.ROCM_PATH = rocmPath;
+    }
+  }
+
+  if (env.ROCM_PATH) {
+    console.log(`🔴 AMD ROCm SDK: ${env.ROCM_PATH}`);
+  } else if (env.HIP_PATH) {
+    console.log(`🔴 AMD HIP SDK: ${env.HIP_PATH}`);
+  } else {
+    console.error('❌ ROCm SDK not found; set ROCM_PATH or HIP_PATH');
+    process.exit(1);
+  }
+
+  if (!env.CMAKE_HIP_COMPILER_ROCM_ROOT) {
+    const sdkPath = env.ROCM_PATH || env.HIP_PATH;
+    const standardRoot = path.join(sdkPath, 'lib', 'cmake', 'hip-lang');
+    const distroRoot = path.resolve(sdkPath, '..', '..');
+    if (fs.existsSync(path.join(standardRoot, 'hip-lang-config.cmake'))) {
+      env.CMAKE_HIP_COMPILER_ROCM_ROOT = sdkPath;
+    } else if (
+      fs.existsSync(path.join(distroRoot, 'lib64', 'cmake', 'hip-lang', 'hip-lang-config.cmake'))
+    ) {
+      env.CMAKE_HIP_COMPILER_ROCM_ROOT = distroRoot;
+    }
+  }
+
+  if (env.CMAKE_HIP_COMPILER_ROCM_ROOT) {
+    console.log(`🔴 HIP CMake root: ${env.CMAKE_HIP_COMPILER_ROCM_ROOT}`);
+  }
+}
 if (platform === 'linux' && feature === 'cuda') {
   console.log('🐧 Linux/CUDA detected: Setting CMAKE flags for NVIDIA GPU');
   env.CMAKE_CUDA_ARCHITECTURES = '75';
   env.CMAKE_CUDA_STANDARD = '17';
   env.CMAKE_POSITION_INDEPENDENT_CODE = 'ON';
 }
-
 // Build the tauri command
 let tauriCmd = `tauri ${command}`;
 if (feature && feature !== 'none') {

--- a/llama-helper/Cargo.toml
+++ b/llama-helper/Cargo.toml
@@ -14,6 +14,7 @@ encoding_rs = "0.8"
 default = []
 metal = ["llama-cpp-2/metal"]
 cuda = ["llama-cpp-2/cuda"]
+rocm = ["llama-cpp-2/rocm"]
 vulkan = ["llama-cpp-2/vulkan"]
 
 [profile.release]

--- a/llama-helper/src/main.rs
+++ b/llama-helper/src/main.rs
@@ -147,6 +147,15 @@ fn detect_vram_gb() -> f32 {
         }
     }
 
+    #[cfg(feature = "rocm")]
+    {
+        // AMD APUs expose their GPU-accessible shared memory through rocminfo.
+        if let Some(vram) = detect_rocm_vram() {
+            eprintln!("ROCm GPU memory detected: {:.2} GB", vram);
+            return vram;
+        }
+    }
+
     /// TODO: Vulkan VRAM detection
 
     eprintln!("VRAM detection not available, using conservative estimate");
@@ -186,6 +195,109 @@ fn detect_cuda_vram() -> Option<f32> {
         }
     }
     None
+}
+
+/// Largest GPU memory pool, in KB, from `rocminfo` output.
+///
+/// Pool sizes are printed with a parenthesised hexadecimal repeat of the same
+/// value, e.g. `Size: 24538072(0x1766bd8) KB`, so the token cannot be parsed as
+/// an integer directly. Only pools belonging to a GPU agent are considered: CPU
+/// agents advertise host memory that is not usable as VRAM. Cache lines such as
+/// `L1: 32(0x20) KB` do not begin with `Size:` and are therefore skipped.
+#[cfg(feature = "rocm")]
+fn parse_rocminfo_vram_kb(stdout: &str) -> Option<u64> {
+    let mut in_gpu_agent = false;
+    let mut largest_pool_kb = 0_u64;
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Agent ") {
+            in_gpu_agent = false;
+        } else if trimmed.starts_with("Device Type:") {
+            in_gpu_agent = trimmed.ends_with("GPU");
+        } else if in_gpu_agent && trimmed.starts_with("Size:") && trimmed.ends_with("KB") {
+            if let Some(size_kb) = trimmed
+                .split_whitespace()
+                .nth(1)
+                .map(|value| value.split('(').next().unwrap_or(value))
+                .and_then(|value| value.parse::<u64>().ok())
+            {
+                largest_pool_kb = largest_pool_kb.max(size_kb);
+            }
+        }
+    }
+
+    (largest_pool_kb > 0).then_some(largest_pool_kb)
+}
+
+#[cfg(feature = "rocm")]
+fn detect_rocm_vram() -> Option<f32> {
+    let output = std::process::Command::new("rocminfo").output().ok()?;
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    parse_rocminfo_vram_kb(&stdout).map(|kb| kb as f32 / (1024.0 * 1024.0))
+}
+
+#[cfg(all(test, feature = "rocm"))]
+mod rocm_vram_tests {
+    use super::parse_rocminfo_vram_kb;
+
+    /// Trimmed to the fields the parser inspects, but the `Size:` lines are
+    /// copied verbatim from `rocminfo` on a Strix Halo system.
+    const SAMPLE: &str = "\
+Agent 1
+  Name:                    AMD Ryzen AI MAX+ PRO 395
+  Device Type:             CPU
+  Pool Info:
+    Pool 1
+      Size:                    49076144(0x2ecd7b0) KB
+Agent 2
+  Name:                    gfx1151
+  Device Type:             GPU
+  Cache Info:
+    L1:                      32(0x20) KB
+    L2:                      2048(0x800) KB
+  Pool Info:
+    Pool 1
+      Size:                    24538072(0x1766bd8) KB
+    Pool 2
+      Size:                    24538072(0x1766bd8) KB
+";
+
+    #[test]
+    fn parses_size_despite_hexadecimal_suffix() {
+        assert_eq!(parse_rocminfo_vram_kb(SAMPLE), Some(24_538_072));
+    }
+
+    #[test]
+    fn ignores_cpu_agent_pools() {
+        // The CPU pool is larger; picking it up would overstate usable VRAM.
+        let vram_kb = parse_rocminfo_vram_kb(SAMPLE).expect("a GPU pool");
+        assert!(vram_kb < 49_076_144, "CPU host memory leaked into VRAM");
+    }
+
+    #[test]
+    fn ignores_gpu_cache_sizes() {
+        // L1/L2 are also reported in KB; they must not win when pools are absent.
+        let cache_only = "\
+Agent 2
+  Device Type:             GPU
+  Cache Info:
+    L1:                      32(0x20) KB
+";
+        assert_eq!(parse_rocminfo_vram_kb(cache_only), None);
+    }
+
+    #[test]
+    fn returns_none_when_no_gpu_agent_present() {
+        let cpu_only = "\
+Agent 1
+  Device Type:             CPU
+  Pool Info:
+    Pool 1
+      Size:                    49076144(0x2ecd7b0) KB
+";
+        assert_eq!(parse_rocminfo_vram_kb(cpu_only), None);
+    }
 }
 
 /// Calculate safe GPU layer count based on VRAM, model file size, and context size


### PR DESCRIPTION
## Problem

Linux AMD systems currently fall back to Vulkan or CPU even when ROCm/HIP is installed. The llama helper also had no ROCm VRAM detection, so layer sizing could not use the GPU's reported memory.

## Fix

- Detect `rocminfo`/`hipcc` in the GPU build and development launchers.
- Select the helper's ROCm feature and provide the Linux ROCm compiler/library paths.
- Parse GPU memory pools from `rocminfo`, including the real `24538072(0x1766bd8) KB` token format.
- Ignore CPU-agent host-memory pools and GPU cache sizes when determining VRAM.

## Verification

- `cargo test --manifest-path llama-helper/Cargo.toml --features rocm rocm_vram_tests` — 4 passed.
- `cargo check --manifest-path llama-helper/Cargo.toml --features rocm`
- `node --check frontend/scripts/auto-detect-gpu.js`
- `node --check frontend/scripts/tauri-auto.js`
- `bash -n frontend/dev-gpu.sh frontend/build-gpu.sh`