### PR TITLE
Run Next directly for Tauri development

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "build": {
         "frontendDist": "../out",
         "devUrl": "http://localhost:3118",
-        "beforeDevCommand": "pnpm dev",
+        "beforeDevCommand": "node node_modules/next/dist/bin/next dev -p 3118",
         "beforeBuildCommand": "node node_modules/next/dist/bin/next build"
     },
     "app": {


### PR DESCRIPTION
## Problem

Tauri's development hook delegates to `npm run dev`, coupling `tauri dev` to an additional package-manager executable even though Next is already installed locally.

## Fix

Run the checked-in Next binary directly:

```text
node node_modules/next/dist/bin/next dev -p 3118
```

This matches the configured `devUrl` and the existing direct Next production-build hook.

## Verification

- Parsed `frontend/src-tauri/tauri.conf.json` as JSON.
- Started the exact command and observed Next ready on port 3118.
- Requested `http://127.0.0.1:3118/` and received the application HTML.