### PR TITLE
Add a Change Folder picker for the recordings save location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Recordings Folder
+
+- Added a Change Folder picker for the recordings save location in Recording
+  and Preference settings; previously the folder was fixed to the platform
+  default.
+- Preferences now display the configured recordings folder instead of always
+  showing the platform default.
+
 ## 0.2.10 - 2026-08-26
 
 ### Light Theme

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ meetings.
 | --- | --- |
 | Database, templates, and models | Windows/Linux: install-local when writable; macOS: `~/Library/Application Support/Meetily` |
 | Recording/onboarding preference stores | macOS: `~/Library/Application Support/com.meetily.ai` |
-| Recordings | Windows: `Music/meetily-recordings`; macOS: `Movies/meetily-recordings` |
+| Recordings | Windows: `Music/meetily-recordings`; macOS: `Movies/meetily-recordings` (configurable in Settings) |
 | Playback and retained tracks | `audio.mp4`, `mic.mp4`, `system.mp4` |
 
 ## Build

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -366,15 +366,39 @@ pub async fn open_recordings_folder<R: Runtime>(app: AppHandle<R>) -> Result<(),
     Ok(())
 }
 
+/// Open a native folder picker for choosing where recordings are saved.
+/// Returns the picked path, or `None` when the user cancels. The caller
+/// persists it via `set_recording_preferences`, which validates writability.
 #[tauri::command]
 pub async fn select_recording_folder<R: Runtime>(
-    _app: AppHandle<R>,
+    app: AppHandle<R>,
 ) -> Result<Option<String>, String> {
-    // Use Tauri's dialog to select folder
-    // For now, return None - this would need to be implemented with tauri-plugin-dialog
-    // when it's available in the Cargo.toml
-    warn!("Folder selection not yet implemented - using dialog plugin");
-    Ok(None)
+    use tauri_plugin_dialog::DialogExt;
+
+    let current = load_recording_preferences(&app)
+        .await
+        .map(|prefs| prefs.save_folder)
+        .unwrap_or_else(|_| get_default_recordings_folder());
+
+    // Blocking dialog; keep it off the async runtime. The plugin dispatches
+    // the native panel to the main thread itself.
+    let picked = tauri::async_runtime::spawn_blocking(move || {
+        let mut dialog = app.dialog().file().set_title("Choose Recordings Folder");
+        if current.is_dir() {
+            dialog = dialog.set_directory(&current);
+        }
+        dialog.blocking_pick_folder()
+    })
+    .await
+    .map_err(|e| format!("Folder picker failed: {e}"))?;
+
+    let Some(path) = picked else {
+        return Ok(None);
+    };
+    let path = path
+        .into_path()
+        .map_err(|e| format!("Invalid folder selection: {e}"))?;
+    Ok(Some(path.to_string_lossy().to_string()))
 }
 
 // Backend selection commands

--- a/frontend/src/components/PreferenceSettings.tsx
+++ b/frontend/src/components/PreferenceSettings.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from "react"
 import { Switch } from "./ui/switch"
-import { FolderOpen } from "lucide-react"
+import { FolderOpen, FolderCog } from "lucide-react"
 import { invoke } from "@tauri-apps/api/core"
 import Analytics from "@/lib/analytics"
 import { useConfig, NotificationSettings } from "@/contexts/ConfigContext"
@@ -21,6 +21,11 @@ export function PreferenceSettings() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [previousNotificationsEnabled, setPreviousNotificationsEnabled] = useState<boolean | null>(null);
   const hasTrackedViewRef = useRef(false);
+
+  // Configured recordings folder; overridden locally after an in-page change
+  // so the display updates without a full preferences reload.
+  const [recordingsFolderOverride, setRecordingsFolderOverride] = useState<string | null>(null);
+  const recordingsFolder = recordingsFolderOverride ?? storageLocations?.recordings;
 
   // "Your name" — used to label the user's mic transcripts as "You (Name)".
   const [userName, setUserName] = useState<string>('');
@@ -157,6 +162,22 @@ export function PreferenceSettings() {
     }
   };
 
+  const handleChangeRecordingsFolder = async () => {
+    try {
+      const selected = await invoke<string | null>('select_recording_folder');
+      if (!selected || selected === recordingsFolder) return;
+
+      const preferences = await invoke<{ save_folder: string }>('get_recording_preferences');
+      await invoke('set_recording_preferences', {
+        preferences: { ...preferences, save_folder: selected }
+      });
+      setRecordingsFolderOverride(selected);
+      await Analytics.track('recordings_folder_changed', {});
+    } catch (error) {
+      console.error('Failed to change recordings folder:', error);
+    }
+  };
+
   // Show loading only if we're actually loading and don't have cached data
   if (isLoadingPreferences && !notificationSettings && !storageLocations) {
     return <div className="max-w-2xl mx-auto p-6">Loading Preferences...</div>
@@ -253,23 +274,35 @@ export function PreferenceSettings() {
           <div className="p-4 border rounded-lg bg-gray-50">
             <div className="font-medium mb-2">Meeting Recordings</div>
             <div className="text-sm text-gray-600 mb-3 break-all font-mono text-xs">
-              {storageLocations?.recordings || 'Loading...'}
+              {recordingsFolder || 'Loading...'}
             </div>
-            <button
-              onClick={() => handleOpenFolder('recordings')}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
-            >
-              <FolderOpen className="w-4 h-4" />
-              Open Folder
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => handleOpenFolder('recordings')}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                <FolderOpen className="w-4 h-4" />
+                Open Folder
+              </button>
+              <button
+                onClick={handleChangeRecordingsFolder}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                <FolderCog className="w-4 h-4" />
+                Change Folder
+              </button>
+            </div>
+            <div className="mt-2 text-xs text-gray-500">
+              New recordings are saved here. Existing recordings stay in their current folder.
+            </div>
           </div>
         </div>
 
         <div className="mt-4 p-3 bg-blue-50 rounded-md">
           <p className="text-xs text-blue-800">
-            <strong>Portable:</strong> Models, database, templates and recordings are all stored together
-            inside this app&apos;s own install folder (<code>…/data</code>). Move or copy the folder and
-            everything travels with it — nothing is scattered across your system.
+            <strong>Portable:</strong> Models, database and templates are stored together inside this
+            app&apos;s own install folder (<code>…/data</code>). Recordings are saved to the folder shown
+            above so they stay easy to find and play with normal tools.
           </p>
         </div>
       </div>

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Switch } from '@/components/ui/switch';
-import { FolderOpen } from 'lucide-react';
+import { FolderOpen, FolderCog } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { DeviceSelection, SelectedDevices } from '@/components/DeviceSelection';
 import Analytics from '@/lib/analytics';
@@ -111,6 +111,33 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       await invoke('open_recordings_folder');
     } catch (error) {
       console.error('Failed to open recordings folder:', error);
+    }
+  };
+
+  const handleChangeFolder = async () => {
+    let selected: string | null;
+    try {
+      selected = await invoke<string | null>('select_recording_folder');
+    } catch (error) {
+      console.error('Failed to open folder picker:', error);
+      toast.error('Failed to open folder picker');
+      return;
+    }
+    if (!selected || selected === preferences.save_folder) return;
+
+    const newPreferences = { ...preferences, save_folder: selected };
+    setSaving(true);
+    try {
+      await invoke('set_recording_preferences', { preferences: newPreferences });
+      setPreferences(newPreferences);
+      onSave?.(newPreferences);
+      toast.success('Save location updated', { description: selected });
+      await Analytics.track('recordings_folder_changed', {});
+    } catch (error) {
+      console.error('Failed to change recordings folder:', error);
+      toast.error('Failed to change save location', { description: String(error) });
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -238,13 +265,26 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
             <div className="mb-3 break-all text-sm text-gray-600">
               {preferences.save_folder || 'Default folder'}
             </div>
-            <button
-              onClick={handleOpenFolder}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-            >
-              <FolderOpen className="w-4 h-4" />
-              Open Folder
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={handleOpenFolder}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                <FolderOpen className="w-4 h-4" />
+                Open Folder
+              </button>
+              <button
+                onClick={handleChangeFolder}
+                disabled={saving}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                <FolderCog className="w-4 h-4" />
+                Change Folder
+              </button>
+            </div>
+            <div className="mt-2 text-xs text-gray-500">
+              New recordings are saved here. Existing recordings stay in their current folder.
+            </div>
           </div>
 
           <div className="p-4 border rounded-lg bg-blue-50">

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -443,11 +443,14 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         setNotificationSettings(null);
       }
 
-      // Load storage locations
+      // Load storage locations. Recordings honor the user-configured
+      // save_folder; fall back to the platform default if prefs fail to load.
       const [dbDir, modelsDir, recordingsDir] = await Promise.all([
         invoke<string>('get_database_directory'),
         invoke<string>('whisper_get_models_directory'),
-        invoke<string>('get_default_recordings_folder_path')
+        invoke<{ save_folder: string }>('get_recording_preferences')
+          .then((prefs) => prefs.save_folder)
+          .catch(() => invoke<string>('get_default_recordings_folder_path'))
       ]);
 
       setStorageLocations({


### PR DESCRIPTION
## Problem

The recordings save location was effectively hardcoded. `select_recording_folder` was a stub returning `None`, with a stale comment claiming `tauri-plugin-dialog` was unavailable even though it is in `Cargo.toml` and registered in `lib.rs`. No UI invoked it, and the Preferences "Meeting Recordings" card always displayed `get_default_recordings_folder_path` — the platform default — so a custom `save_folder` would never be shown even though the backend persists, validates, and honors it at recording start.

## Fix

- Implemented `select_recording_folder` using the dialog plugin's native folder picker (`blocking_pick_folder` off the async runtime, starting at the currently configured folder, `None` on cancel — cancelling leaves the existing preference untouched).
- Added a **Change Folder** button beside **Open Folder** in Recording settings and in Preferences → Meeting Recordings. Picks persist through the existing `set_recording_preferences` path, which already validates writability before saving.
- Preferences now display the configured `save_folder` (falling back to the platform default only if preferences fail to load).
- Added the hint "New recordings are saved here. Existing recordings stay in their current folder." — meetings keep absolute paths in the database, so playback of prior recordings is unaffected.
- Corrected the adjacent "Portable" note and the README Local Data row: recordings live in the user-facing media folder (now configurable), not the install folder.

No new commands: `select_recording_folder` was already registered in the invoke handler; the `discard_recording_folder` safety check already treats a custom `save_folder` as a valid recordings root.

## Verification

- Full macOS Apple Silicon `tauri build` of this branch (Rust + Next.js type-checked production build).
- App bundle installed and launched cleanly on macOS 26.1 (Apple Silicon); the settings surfaces render the configured folder.
- The native folder panel itself was not driven by automation; persistence/validation of the picked path reuses the pre-existing `set_recording_preferences` flow (`ensure_recordings_directory` before save).
