### PR TITLE
Native PipeWire/PulseAudio audio capture on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libpulse-binding"
+version = "2.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "libpulse-simple-binding"
+version = "2.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bebef0381c8e3e4b23cc24aaf36fab37472bece128de96f6a111efa464cfef"
+dependencies = [
+ "libpulse-binding",
+ "libpulse-simple-sys",
+ "libpulse-sys",
+]
+
+[[package]]
+name = "libpulse-simple-sys"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd96888fe37ad270d16abf5e82cccca1424871cf6afa2861824d2a52758eebc"
+dependencies = [
+ "libpulse-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74371848b22e989f829cc1621d2ebd74960711557d8b45cfe740f60d0a05e61"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3684,8 @@ dependencies = [
  "futures-util",
  "infer 0.15.0",
  "lazy_static",
+ "libpulse-binding",
+ "libpulse-simple-binding",
  "log",
  "memory-stats",
  "ndarray",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -212,6 +212,11 @@ futures-channel = "0.3.31"
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
 
+# Native PipeWire/PulseAudio client for system-audio capture (bypasses cpal's
+# ALSA-only host on Linux, no ~/.asoundrc setup required)
+libpulse-binding = "2.30.1"
+libpulse-simple-binding = "2.29.0"
+
 [dev-dependencies]
 tempfile = "3.3.0"
 infer = "0.15"

--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -21,7 +21,11 @@ pub use system::{
 pub use core_audio::{CoreAudioCapture, CoreAudioStream};
 
 #[cfg(target_os = "linux")]
-pub use pulse_linux::{PulseSink, PulseSystemCapture, list_sinks as list_pulse_sinks, find_monitor_source_by_description};
+pub use pulse_linux::{
+    PulseCapture, PulseSink, PulseSource,
+    default_source_description, find_monitor_source_by_description, find_source_by_description,
+    list_sinks as list_pulse_sinks, list_sources as list_pulse_sources,
+};
 
 // Re-export backend configuration
 pub use backend_config::{

--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -7,6 +7,9 @@ pub mod backend_config;
 #[cfg(target_os = "macos")]
 pub mod core_audio;
 
+#[cfg(target_os = "linux")]
+pub mod pulse_linux;
+
 // Re-export capture functionality
 pub use system::{
     SystemAudioCapture, SystemAudioStream,
@@ -16,6 +19,9 @@ pub use system::{
 
 #[cfg(target_os = "macos")]
 pub use core_audio::{CoreAudioCapture, CoreAudioStream};
+
+#[cfg(target_os = "linux")]
+pub use pulse_linux::{PulseSink, PulseSystemCapture, list_sinks as list_pulse_sinks, find_monitor_source_by_description};
 
 // Re-export backend configuration
 pub use backend_config::{

--- a/frontend/src-tauri/src/audio/capture/pulse_linux.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse_linux.rs
@@ -379,6 +379,14 @@ impl PulseCapture {
                 break;
             }
 
+            // Re-check right after the blocking read returns: if stop() timed
+            // out waiting for this thread (stalled source) and moved on, a
+            // late read() shouldn't inject one more chunk into whatever
+            // pipeline state now exists (new stream, new recording).
+            if self.should_stop.load(Ordering::Acquire) {
+                break;
+            }
+
             sample_buf.clear();
             sample_buf.extend(
                 byte_buf

--- a/frontend/src-tauri/src/audio/capture/pulse_linux.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse_linux.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use libpulse_binding::callbacks::ListResult;
+use libpulse_binding::context::introspect::ServerInfo;
 use libpulse_binding::context::{Context, FlagSet as ContextFlagSet, State as ContextState};
 use libpulse_binding::mainloop::standard::{IterateResult, Mainloop};
 use libpulse_binding::operation::{Operation, State as OperationState};
@@ -35,7 +36,6 @@ pub struct PulseSink {
 /// server-side, so the rest of the pipeline (which expects 48kHz) never needs
 /// to know the sink's native sample rate or channel count.
 const CAPTURE_SAMPLE_RATE: u32 = 48000;
-const CAPTURE_CHANNELS: u16 = 2;
 
 /// Pump the mainloop until `operation` finishes, blocking between iterations.
 fn run_operation_to_completion<T: ?Sized>(
@@ -163,18 +163,150 @@ pub fn find_monitor_source_by_description(description: &str) -> Result<String> {
         .ok_or_else(|| anyhow!("No PulseAudio sink found matching '{}'", description))
 }
 
-/// Blocking system-audio capture stream, backed by libpulse-simple's record API
-/// against a sink's monitor source.
-pub struct PulseSystemCapture {
-    simple: Simple,
-    should_stop: Arc<AtomicBool>,
+/// A PulseAudio input source (microphone, line-in, …), excluding sink monitors.
+#[derive(Debug, Clone)]
+pub struct PulseSource {
+    /// Human-readable description straight from the server — this is the exact
+    /// string KDE's own audio settings show (e.g. "Ryzen HD Audio Controller
+    /// Headset Mono Microphone").
+    pub description: String,
+    /// Real PulseAudio source name, e.g.
+    /// "alsa_input.pci-0000_c1_00.6.HiFi__Headset__source".
+    pub source_name: String,
 }
 
-impl PulseSystemCapture {
-    pub fn new(monitor_source_name: &str) -> Result<Self> {
+/// List all real input sources (sink monitors excluded — those are offered as
+/// "System Audio" devices via `list_sinks`).
+pub fn list_sources() -> Result<Vec<PulseSource>> {
+    info!("🎤 pulse_linux::list_sources: connecting");
+    let (mut mainloop, context) = connect()?;
+
+    info!("🎤 pulse_linux::list_sources: connected, requesting source list");
+    let sources: Rc<RefCell<Vec<PulseSource>>> = Rc::new(RefCell::new(Vec::new()));
+    let sources_cb = sources.clone();
+
+    let operation = context.introspect().get_source_info_list(move |result| {
+        if let ListResult::Item(info) = result {
+            // Monitors of sinks are already exposed as "System Audio" devices
+            // through list_sinks(); ignore them here.
+            if info.monitor_of_sink.is_some() {
+                return;
+            }
+
+            let source_name = info.name.as_deref().unwrap_or_default();
+            if source_name.is_empty() {
+                return;
+            }
+
+            let description = info
+                .description
+                .as_deref()
+                .unwrap_or(source_name)
+                .to_string();
+
+            sources_cb.borrow_mut().push(PulseSource {
+                description,
+                source_name: source_name.to_string(),
+            });
+        }
+    });
+
+    info!("🎤 pulse_linux::list_sources: pumping mainloop until source list operation completes");
+    run_operation_to_completion(&mut mainloop, &operation)?;
+    drop(operation);
+
+    let result = sources.borrow().clone();
+    info!("🎤 pulse_linux::list_sources: got {} source(s)", result.len());
+    Ok(result)
+}
+
+/// Resolve a source's real PulseAudio name from its display description.
+pub fn find_source_by_description(description: &str) -> Result<String> {
+    let mut matches = list_sources()?
+        .into_iter()
+        .filter(|source| source.description == description)
+        .peekable();
+
+    if matches.peek().is_some() {
+        let count = matches.clone().count();
+        if count > 1 {
+            warn!(
+                "🎤 pulse_linux::find_source_by_description: {} sources share the description '{}'; using the first one",
+                count, description
+            );
+        }
+    }
+
+    matches
+        .next()
+        .map(|source| source.source_name)
+        .ok_or_else(|| anyhow!("No PulseAudio source found matching '{}'", description))
+}
+
+/// Description of the server's default input source, if any.
+/// Used to resolve "Default Microphone".
+pub fn default_source_description() -> Result<Option<String>> {
+    info!("🎤 pulse_linux::default_source_description: connecting");
+    let (mut mainloop, context) = connect()?;
+
+    info!("🎤 pulse_linux::default_source_description: requesting server info");
+    let default_name: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    let default_name_cb = default_name.clone();
+
+    let operation = context.introspect().get_server_info(move |info: &ServerInfo| {
+        if let Some(name) = info.default_source_name.as_deref() {
+            *default_name_cb.borrow_mut() = Some(name.to_string());
+        }
+    });
+
+    run_operation_to_completion(&mut mainloop, &operation)?;
+    drop(operation);
+
+    let default_name = default_name.borrow().clone();
+    let Some(default_name) = default_name else {
+        return Ok(None);
+    };
+
+    info!(
+        "🎤 pulse_linux::default_source_description: default source name is '{}'",
+        default_name
+    );
+
+    // Resolve the display description for the default source. Do a second
+    // introspection call: it's rare (startup of a recording) and keeps the code
+    // straightforward.
+    let sources = list_sources()?;
+    let default_source = sources.iter().find(|s| s.source_name == default_name);
+
+    if let Some(source) = default_source {
+        info!(
+            "🎤 pulse_linux::default_source_description: default source description is '{}'",
+            source.description
+        );
+        Ok(Some(source.description.clone()))
+    } else {
+        warn!(
+            "🎤 pulse_linux::default_source_description: default source '{}' not found in source list",
+            default_name
+        );
+        Ok(None)
+    }
+}
+
+/// Blocking PulseAudio record stream, backed by libpulse-simple's record API.
+/// Used both for sink monitors (system audio) and real input sources
+/// (microphones).
+pub struct PulseCapture {
+    simple: Simple,
+    should_stop: Arc<AtomicBool>,
+    channels: u16,
+}
+
+impl PulseCapture {
+    fn new_with_channels(source_name: &str, channels: u16, stream_label: &str) -> Result<Self> {
         let spec = Spec {
             format: Format::FLOAT32NE,
-            channels: CAPTURE_CHANNELS as u8,
+            channels: channels as u8,
             rate: CAPTURE_SAMPLE_RATE,
         };
         if !spec.is_valid() {
@@ -185,8 +317,8 @@ impl PulseSystemCapture {
             None, // default server
             "Meetily",
             Direction::Record,
-            Some(monitor_source_name),
-            "System Audio",
+            Some(source_name),
+            stream_label,
             &spec,
             None, // default channel map
             None, // default buffering attributes
@@ -194,7 +326,7 @@ impl PulseSystemCapture {
         .map_err(|e| {
             anyhow!(
                 "Failed to open PulseAudio record stream on '{}': {}",
-                monitor_source_name,
+                source_name,
                 e
             )
         })?;
@@ -202,7 +334,19 @@ impl PulseSystemCapture {
         Ok(Self {
             simple,
             should_stop: Arc::new(AtomicBool::new(false)),
+            channels,
         })
+    }
+
+    /// System audio: stereo capture of a sink's monitor source.
+    pub fn new_system(monitor_source_name: &str) -> Result<Self> {
+        Self::new_with_channels(monitor_source_name, 2, "System Audio")
+    }
+
+    /// Microphone: mono capture of a real input source. PulseAudio downmixes and
+    /// resamples server-side, so the pipeline still receives 48kHz.
+    pub fn new_microphone(source_name: &str) -> Result<Self> {
+        Self::new_with_channels(source_name, 1, "Microphone")
     }
 
     pub fn sample_rate(&self) -> u32 {
@@ -210,7 +354,7 @@ impl PulseSystemCapture {
     }
 
     pub fn channels(&self) -> u16 {
-        CAPTURE_CHANNELS
+        self.channels
     }
 
     /// Handle used to signal the capture loop (running on another thread) to stop.
@@ -226,8 +370,8 @@ impl PulseSystemCapture {
         // ~21ms at 48kHz stereo: matches the 1024-frame chunking used by the
         // macOS Core Audio path.
         const FRAMES_PER_CHUNK: usize = 1024;
-        let mut byte_buf = vec![0u8; FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize * 4];
-        let mut sample_buf = Vec::with_capacity(FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize);
+        let mut byte_buf = vec![0u8; FRAMES_PER_CHUNK * self.channels as usize * 4];
+        let mut sample_buf = Vec::with_capacity(FRAMES_PER_CHUNK * self.channels as usize);
 
         while !self.should_stop.load(Ordering::Acquire) {
             if let Err(e) = self.simple.read(&mut byte_buf) {
@@ -262,6 +406,16 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Requires a running PulseAudio/PipeWire server; run manually.
+    fn test_list_sources() {
+        let sources = list_sources().expect("Failed to list sources");
+        for source in &sources {
+            println!("source: {} -> {}", source.description, source.source_name);
+        }
+        assert!(!sources.is_empty(), "Expected at least one real input source on a machine with audio input");
+    }
+
+    #[test]
     #[ignore] // Requires real audio playback during the test; run manually.
     fn test_capture_reads_nonzero_samples() {
         let sinks = list_sinks().expect("Failed to list sinks");
@@ -273,7 +427,7 @@ mod tests {
             .expect("No sink available");
 
         println!("Capturing from: {} ({})", sink.description, sink.monitor_source_name);
-        let capture = PulseSystemCapture::new(&sink.monitor_source_name).expect("Failed to open capture");
+        let capture = PulseCapture::new_system(&sink.monitor_source_name).expect("Failed to open capture");
         let stop = capture.stop_handle();
 
         let received = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/frontend/src-tauri/src/audio/capture/pulse_linux.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse_linux.rs
@@ -1,0 +1,299 @@
+// Native PipeWire/PulseAudio system-audio capture for Linux.
+//
+// Bypasses cpal's ALSA-only host entirely by talking to the PulseAudio client
+// protocol directly (which PipeWire also implements via pipewire-pulse). This
+// avoids the need to hand-register monitor sources as named ALSA pseudo-devices
+// in ~/.asoundrc: sink descriptions and monitor sources come straight from the
+// server's real metadata.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use libpulse_binding::callbacks::ListResult;
+use libpulse_binding::context::{Context, FlagSet as ContextFlagSet, State as ContextState};
+use libpulse_binding::mainloop::standard::{IterateResult, Mainloop};
+use libpulse_binding::operation::{Operation, State as OperationState};
+use libpulse_binding::proplist::Proplist;
+use libpulse_binding::sample::{Format, Spec};
+use libpulse_binding::stream::Direction;
+use libpulse_simple_binding::Simple;
+use log::{info, warn};
+
+/// A PulseAudio sink, with the metadata needed to offer it as a "System Audio"
+/// capture device: a real display description and its monitor source name.
+#[derive(Debug, Clone)]
+pub struct PulseSink {
+    pub description: String,
+    pub monitor_source_name: String,
+}
+
+/// Fixed capture format requested from the server. PulseAudio/PipeWire
+/// transparently resamples and remixes the monitor source to this spec
+/// server-side, so the rest of the pipeline (which expects 48kHz) never needs
+/// to know the sink's native sample rate or channel count.
+const CAPTURE_SAMPLE_RATE: u32 = 48000;
+const CAPTURE_CHANNELS: u16 = 2;
+
+/// Pump the mainloop until `operation` finishes, blocking between iterations.
+fn run_operation_to_completion<T: ?Sized>(
+    mainloop: &mut Mainloop,
+    operation: &Operation<T>,
+) -> Result<()> {
+    loop {
+        match mainloop.iterate(true) {
+            IterateResult::Quit(_) | IterateResult::Err(_) => {
+                return Err(anyhow!("PulseAudio mainloop iteration failed"));
+            }
+            IterateResult::Success(_) => {}
+        }
+
+        match operation.get_state() {
+            OperationState::Done => return Ok(()),
+            OperationState::Cancelled => {
+                return Err(anyhow!("PulseAudio operation was cancelled"));
+            }
+            OperationState::Running => continue,
+        }
+    }
+}
+
+/// Connect a fresh context to the default PulseAudio/PipeWire server, blocking
+/// until it's ready. Each call opens (and the caller later drops) its own
+/// connection — unlike ALSA's cached global config, there's no stale-state
+/// problem to work around here, so every call sees the server's current sinks.
+fn connect() -> Result<(Mainloop, Context)> {
+    info!("🔊 pulse_linux::connect: creating mainloop");
+    let mut mainloop =
+        Mainloop::new().ok_or_else(|| anyhow!("Failed to create PulseAudio mainloop"))?;
+
+    let proplist =
+        Proplist::new().ok_or_else(|| anyhow!("Failed to create PulseAudio proplist"))?;
+    let mut context = Context::new_with_proplist(&mainloop, "Meetily", &proplist)
+        .ok_or_else(|| anyhow!("Failed to create PulseAudio context"))?;
+
+    info!("🔊 pulse_linux::connect: calling context.connect()");
+    context
+        .connect(None, ContextFlagSet::NOFLAGS, None)
+        .map_err(|e| anyhow!("Failed to connect to PulseAudio/PipeWire server: {}", e))?;
+
+    info!("🔊 pulse_linux::connect: waiting for context to become Ready");
+    let mut iterations: u32 = 0;
+    loop {
+        iterations += 1;
+        if iterations % 50 == 0 {
+            info!("🔊 pulse_linux::connect: still waiting after {} iterations, state={:?}", iterations, context.get_state());
+        }
+
+        match mainloop.iterate(true) {
+            IterateResult::Quit(_) | IterateResult::Err(_) => {
+                return Err(anyhow!(
+                    "PulseAudio mainloop iteration failed while connecting"
+                ));
+            }
+            IterateResult::Success(_) => {}
+        }
+
+        match context.get_state() {
+            ContextState::Ready => break,
+            ContextState::Failed | ContextState::Terminated => {
+                return Err(anyhow!(
+                    "PulseAudio/PipeWire context connection failed or was terminated"
+                ));
+            }
+            _ => {}
+        }
+    }
+    info!("🔊 pulse_linux::connect: context Ready after {} iterations", iterations);
+
+    Ok((mainloop, context))
+}
+
+/// List all sinks (playback outputs) with their monitor source name, for use as
+/// "System Audio" capture devices. Descriptions come straight from the server —
+/// no manual ~/.asoundrc registration needed, and switching outputs (new DAC,
+/// different Bluetooth device) is picked up on the next call since nothing here
+/// is cached between calls.
+pub fn list_sinks() -> Result<Vec<PulseSink>> {
+    info!("🔊 pulse_linux::list_sinks: connecting");
+    let (mut mainloop, context) = connect()?;
+
+    info!("🔊 pulse_linux::list_sinks: connected, requesting sink list");
+    let sinks: Rc<RefCell<Vec<PulseSink>>> = Rc::new(RefCell::new(Vec::new()));
+    let sinks_cb = sinks.clone();
+
+    let operation = context.introspect().get_sink_info_list(move |result| {
+        if let ListResult::Item(info) = result {
+            let monitor_source_name = info.monitor_source_name.as_deref().unwrap_or_default();
+            if monitor_source_name.is_empty() {
+                return;
+            }
+
+            let description = info
+                .description
+                .as_deref()
+                .unwrap_or("Unknown output")
+                .to_string();
+
+            sinks_cb.borrow_mut().push(PulseSink {
+                description,
+                monitor_source_name: monitor_source_name.to_string(),
+            });
+        }
+    });
+
+    info!("🔊 pulse_linux::list_sinks: pumping mainloop until sink list operation completes");
+    run_operation_to_completion(&mut mainloop, &operation)?;
+    drop(operation);
+
+    let result = sinks.borrow().clone();
+    info!("🔊 pulse_linux::list_sinks: got {} sink(s)", result.len());
+    Ok(result)
+}
+
+/// Resolve a sink's real monitor source name from its display description (as
+/// shown in the "System Audio" picker, e.g. "JBL Tune 770NC").
+pub fn find_monitor_source_by_description(description: &str) -> Result<String> {
+    list_sinks()?
+        .into_iter()
+        .find(|sink| sink.description == description)
+        .map(|sink| sink.monitor_source_name)
+        .ok_or_else(|| anyhow!("No PulseAudio sink found matching '{}'", description))
+}
+
+/// Blocking system-audio capture stream, backed by libpulse-simple's record API
+/// against a sink's monitor source.
+pub struct PulseSystemCapture {
+    simple: Simple,
+    should_stop: Arc<AtomicBool>,
+}
+
+impl PulseSystemCapture {
+    pub fn new(monitor_source_name: &str) -> Result<Self> {
+        let spec = Spec {
+            format: Format::FLOAT32NE,
+            channels: CAPTURE_CHANNELS as u8,
+            rate: CAPTURE_SAMPLE_RATE,
+        };
+        if !spec.is_valid() {
+            return Err(anyhow!("Invalid PulseAudio sample spec"));
+        }
+
+        let simple = Simple::new(
+            None, // default server
+            "Meetily",
+            Direction::Record,
+            Some(monitor_source_name),
+            "System Audio",
+            &spec,
+            None, // default channel map
+            None, // default buffering attributes
+        )
+        .map_err(|e| {
+            anyhow!(
+                "Failed to open PulseAudio record stream on '{}': {}",
+                monitor_source_name,
+                e
+            )
+        })?;
+
+        Ok(Self {
+            simple,
+            should_stop: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        CAPTURE_SAMPLE_RATE
+    }
+
+    pub fn channels(&self) -> u16 {
+        CAPTURE_CHANNELS
+    }
+
+    /// Handle used to signal the capture loop (running on another thread) to stop.
+    pub fn stop_handle(&self) -> Arc<AtomicBool> {
+        self.should_stop.clone()
+    }
+
+    /// Runs a blocking read loop, invoking `on_samples` with interleaved f32
+    /// frames as they arrive. Meant to run on a `spawn_blocking` task, since
+    /// PulseAudio's simple API blocks on `read()`. Returns once `stop_handle()`
+    /// is signalled or the stream errors out.
+    pub fn run(&self, mut on_samples: impl FnMut(&[f32])) {
+        // ~21ms at 48kHz stereo: matches the 1024-frame chunking used by the
+        // macOS Core Audio path.
+        const FRAMES_PER_CHUNK: usize = 1024;
+        let mut byte_buf = vec![0u8; FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize * 4];
+        let mut sample_buf = Vec::with_capacity(FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize);
+
+        while !self.should_stop.load(Ordering::Acquire) {
+            if let Err(e) = self.simple.read(&mut byte_buf) {
+                warn!("PulseAudio record stream read error: {}", e);
+                break;
+            }
+
+            sample_buf.clear();
+            sample_buf.extend(
+                byte_buf
+                    .chunks_exact(4)
+                    .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]])),
+            );
+
+            on_samples(&sample_buf);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore] // Requires a running PulseAudio/PipeWire server; run manually.
+    fn test_list_sinks() {
+        let sinks = list_sinks().expect("Failed to list sinks");
+        for sink in &sinks {
+            println!("sink: {} -> monitor {}", sink.description, sink.monitor_source_name);
+        }
+        assert!(!sinks.is_empty(), "Expected at least one sink on a machine with audio output");
+    }
+
+    #[test]
+    #[ignore] // Requires real audio playback during the test; run manually.
+    fn test_capture_reads_nonzero_samples() {
+        let sinks = list_sinks().expect("Failed to list sinks");
+        let sink = sinks
+            .into_iter()
+            .find(|s| s.monitor_source_name.to_lowercase().contains("bluez")
+                || s.monitor_source_name.to_lowercase().contains("running"))
+            .or_else(|| list_sinks().unwrap().into_iter().next())
+            .expect("No sink available");
+
+        println!("Capturing from: {} ({})", sink.description, sink.monitor_source_name);
+        let capture = PulseSystemCapture::new(&sink.monitor_source_name).expect("Failed to open capture");
+        let stop = capture.stop_handle();
+
+        let received = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let received_clone = received.clone();
+        let stop_clone = stop.clone();
+        let handle = std::thread::spawn(move || {
+            capture.run(|samples| {
+                received_clone.fetch_add(samples.len(), std::sync::atomic::Ordering::Relaxed);
+                if received_clone.load(std::sync::atomic::Ordering::Relaxed) > 48000 * 2 {
+                    stop_clone.store(true, std::sync::atomic::Ordering::Release);
+                }
+            });
+        });
+
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        stop.store(true, std::sync::atomic::Ordering::Release);
+        handle.join().unwrap();
+
+        let total = received.load(std::sync::atomic::Ordering::Relaxed);
+        println!("Received {} samples", total);
+        assert!(total > 0, "Expected to receive some samples from the monitor source");
+    }
+}

--- a/frontend/src-tauri/src/audio/capture/pulse_linux.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse_linux.rs
@@ -156,9 +156,22 @@ pub fn list_sinks() -> Result<Vec<PulseSink>> {
 /// Resolve a sink's real monitor source name from its display description (as
 /// shown in the "System Audio" picker, e.g. "JBL Tune 770NC").
 pub fn find_monitor_source_by_description(description: &str) -> Result<String> {
-    list_sinks()?
+    info!("🔍 find_monitor_source_by_description: searching for '{}'", description);
+    let sinks = list_sinks()?;
+    info!("🔍 Available sinks:");
+    for sink in &sinks {
+        info!("  - '{}' -> monitor: '{}'", sink.description, sink.monitor_source_name);
+    }
+
+    sinks
         .into_iter()
-        .find(|sink| sink.description == description)
+        .find(|sink| {
+            let matches = sink.description == description;
+            if matches {
+                info!("✅ Found match: '{}' -> monitor: '{}'", sink.description, sink.monitor_source_name);
+            }
+            matches
+        })
         .map(|sink| sink.monitor_source_name)
         .ok_or_else(|| anyhow!("No PulseAudio sink found matching '{}'", description))
 }
@@ -313,6 +326,25 @@ impl PulseCapture {
             return Err(anyhow!("Invalid PulseAudio sample spec"));
         }
 
+        // Match fragsize exactly to our read buffer (1024 frames) to prevent timing issues.
+        // This ensures PulseAudio delivers exactly what we're reading each iteration.
+        use libpulse_binding::def::BufferAttr;
+
+        const FRAMES_PER_CHUNK: u32 = 1024; // must match the constant in run()
+        let fragsize = FRAMES_PER_CHUNK * channels as u32 * 4; // bytes per chunk
+        let maxlength = (CAPTURE_SAMPLE_RATE / 2) * channels as u32 * 4; // 500ms max buffer
+
+        let buffer_attr = BufferAttr {
+            maxlength,      // 500ms max buffer to survive CPU spikes
+            tlength: std::u32::MAX,   // not used for record streams
+            prebuf: std::u32::MAX,    // not used for record streams
+            minreq: std::u32::MAX,    // not used for record streams
+            fragsize,       // exactly match our read buffer size
+        };
+
+        info!("🔊 PulseAudio buffer: fragsize=1024 frames (~21ms), maxlength={}ms",
+              maxlength as f32 / (CAPTURE_SAMPLE_RATE * channels as u32 * 4) as f32 * 1000.0);
+
         let simple = Simple::new(
             None, // default server
             "Meetily",
@@ -321,7 +353,7 @@ impl PulseCapture {
             stream_label,
             &spec,
             None, // default channel map
-            None, // default buffering attributes
+            Some(&buffer_attr), // large max buffer, default timing
         )
         .map_err(|e| {
             anyhow!(

--- a/frontend/src-tauri/src/audio/capture/system.rs
+++ b/frontend/src-tauri/src/audio/capture/system.rs
@@ -24,6 +24,13 @@ impl SystemAudioCapture {
     }
 
     pub fn list_system_devices() -> Result<Vec<String>> {
+        // See ALSA_GLOBAL_LOCK doc comment in devices/platform/linux.rs: any
+        // alsa-lib enumeration must be serialized on Linux.
+        #[cfg(target_os = "linux")]
+        let _guard = crate::audio::devices::platform::linux::ALSA_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
         let host = cpal::default_host();
         let devices = host.output_devices()
             .map_err(|e| anyhow::anyhow!("Failed to enumerate output devices: {}", e))?;
@@ -104,6 +111,12 @@ impl SystemAudioCapture {
     }
 
     pub fn check_system_audio_permissions() -> bool {
+        // See ALSA_GLOBAL_LOCK doc comment in devices/platform/linux.rs.
+        #[cfg(target_os = "linux")]
+        let _guard = crate::audio::devices::platform::linux::ALSA_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
         // Check if we can enumerate audio devices
         match cpal::default_host().output_devices() {
             Ok(_) => true,

--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -124,6 +124,11 @@ pub async fn get_device_and_config(
 
         match audio_device.device_type {
             DeviceType::Input => {
+                #[cfg(target_os = "linux")]
+                let _guard = super::platform::linux::ALSA_GLOBAL_LOCK
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+
                 for device in host.input_devices()? {
                     if let Ok(name) = device.name() {
                         if name == audio_device.name {
@@ -154,7 +159,12 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
+                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // Serialize every alsa-lib call: see ALSA_GLOBAL_LOCK doc comment.
+                    let _guard = super::platform::linux::ALSA_GLOBAL_LOCK
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+
                     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
                         for device in pulse_host.input_devices()? {
                             if let Ok(name) = device.name() {

--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -159,7 +159,42 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // For Linux system audio with "(System Audio)" suffix, we use native
+                    // PulseAudio capture which doesn't go through CPAL. Validate by
+                    // checking if the sink exists in PulseAudio.
+                    if audio_device.name.contains("(System Audio)") {
+                        use crate::audio::capture::pulse_linux;
+
+                        // Strip "(System Audio)" to get the sink description
+                        let sink_desc = audio_device.name
+                            .strip_suffix(" (System Audio)")
+                            .unwrap_or(&audio_device.name);
+
+                        // Check if this sink exists in PulseAudio
+                        match pulse_linux::find_monitor_source_by_description(sink_desc) {
+                            Ok(_monitor_source) => {
+                                // Device exists! Return a dummy CPAL device since the actual
+                                // stream creation in stream.rs will use PulseCapture directly
+                                let host = cpal::default_host();
+                                let dummy_device = host
+                                    .default_input_device()
+                                    .ok_or_else(|| anyhow!("No default input device"))?;
+                                let config = dummy_device
+                                    .default_input_config()
+                                    .map_err(|e| anyhow!("Failed to get config: {}", e))?;
+                                return Ok((dummy_device, config));
+                            }
+                            Err(e) => {
+                                return Err(anyhow!(
+                                    "PulseAudio sink '{}' not found: {}",
+                                    sink_desc,
+                                    e
+                                ));
+                            }
+                        }
+                    }
+
+                    // For fallback ALSA devices, validate they exist in CPAL
                     // Serialize every alsa-lib call: see ALSA_GLOBAL_LOCK doc comment.
                     let _guard = super::platform::linux::ALSA_GLOBAL_LOCK
                         .lock()

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use log::{error, info};
 
-use super::configuration::{AudioDevice, DeviceType};
+use super::configuration::AudioDevice;
 use super::platform;
 
 /// List all available audio devices on the system
@@ -11,6 +11,7 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     let host = cpal::default_host();
 
     // Platform-specific device enumeration
+    #[allow(unused_mut)]
     let mut devices = {
         #[cfg(target_os = "windows")]
         {
@@ -32,20 +33,23 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     };
     info!("🎙️ list_audio_devices: platform enumeration done, {} device(s) so far", devices.len());
 
-    // Add any additional devices from the default host
-    // On Linux this also enumerates via alsa-lib, so it must go through the
-    // same lock as configure_linux_audio (see ALSA_ENUM_LOCK's doc comment).
-    let other_devices_result = {
-        #[cfg(target_os = "linux")]
-        let _guard = platform::linux::ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // Add any additional devices from the default host.
+    //
+    // On Linux this is intentionally disabled: configure_linux_audio() already
+    // provides every useful device (PulseAudio/PipeWire sources and sinks, or a
+    // filtered ALSA fallback). This block would otherwise re-inject all raw ALSA
+    // PCM names as Output devices, polluting the "System Audio" picker with
+    // entries like hdmi:, front:, sysdefault:, etc.
+    #[cfg(not(target_os = "linux"))]
+    {
+        use super::configuration::DeviceType;
 
-        host.devices()
-    };
-    if let Ok(other_devices) = other_devices_result {
-        for device in other_devices {
-            if let Ok(name) = device.name() {
-                if !devices.iter().any(|d| d.name == name) {
-                    devices.push(AudioDevice::new(name, DeviceType::Output));
+        if let Ok(other_devices) = host.devices() {
+            for device in other_devices {
+                if let Ok(name) = device.name() {
+                    if !devices.iter().any(|d| d.name == name) {
+                        devices.push(AudioDevice::new(name, DeviceType::Output));
+                    }
                 }
             }
         }

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -63,43 +63,51 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
 pub fn trigger_audio_permission() -> Result<bool> {
     use log::info;
 
-    // Serialize every alsa-lib call on Linux: see ALSA_GLOBAL_LOCK doc comment
-    // in devices/platform/linux.rs.
-    #[cfg(target_os = "linux")]
-    let _guard = platform::linux::ALSA_GLOBAL_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-
     let host = cpal::default_host();
-    let device = match host.default_input_device() {
-        Some(d) => d,
-        None => {
-            info!("[trigger_audio_permission] No default input device found - permission likely denied");
-            return Ok(false);
-        }
-    };
 
-    let config = match device.default_input_config() {
-        Ok(c) => c,
-        Err(e) => {
-            info!("[trigger_audio_permission] Failed to get input config: {} - permission likely denied", e);
-            return Ok(false);
-        }
-    };
+    // Serialize only the alsa-lib calls that touch the global config cache
+    // (device/config lookup, PCM open via build_input_stream): see
+    // ALSA_GLOBAL_LOCK doc comment in devices/platform/linux.rs. play()/sleep/
+    // drop() below operate on an already-open handle and don't need the lock —
+    // holding it that long would needlessly block every other Linux audio
+    // caller (device_monitor's poll, a stream starting elsewhere) for the
+    // ~500ms this function sleeps.
+    let stream = {
+        #[cfg(target_os = "linux")]
+        let _guard = platform::linux::ALSA_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
-    // Build and start an input stream to trigger the permission request
-    let stream = match device.build_input_stream(
-        &config.into(),
-        |_data: &[f32], _: &cpal::InputCallbackInfo| {
-            // Do nothing, we just want to trigger the permission request
-        },
-        |err| error!("Error in audio stream: {}", err),
-        None,
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            info!("[trigger_audio_permission] Failed to build input stream: {} - permission likely denied", e);
-            return Ok(false);
+        let device = match host.default_input_device() {
+            Some(d) => d,
+            None => {
+                info!("[trigger_audio_permission] No default input device found - permission likely denied");
+                return Ok(false);
+            }
+        };
+
+        let config = match device.default_input_config() {
+            Ok(c) => c,
+            Err(e) => {
+                info!("[trigger_audio_permission] Failed to get input config: {} - permission likely denied", e);
+                return Ok(false);
+            }
+        };
+
+        // Build and start an input stream to trigger the permission request
+        match device.build_input_stream(
+            &config.into(),
+            |_data: &[f32], _: &cpal::InputCallbackInfo| {
+                // Do nothing, we just want to trigger the permission request
+            },
+            |err| error!("Error in audio stream: {}", err),
+            None,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                info!("[trigger_audio_permission] Failed to build input stream: {} - permission likely denied", e);
+                return Ok(false);
+            }
         }
     };
 

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -33,7 +33,15 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     info!("🎙️ list_audio_devices: platform enumeration done, {} device(s) so far", devices.len());
 
     // Add any additional devices from the default host
-    if let Ok(other_devices) = host.devices() {
+    // On Linux this also enumerates via alsa-lib, so it must go through the
+    // same lock as configure_linux_audio (see ALSA_ENUM_LOCK's doc comment).
+    let other_devices_result = {
+        #[cfg(target_os = "linux")]
+        let _guard = platform::linux::ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        host.devices()
+    };
+    if let Ok(other_devices) = other_devices_result {
         for device in other_devices {
             if let Ok(name) = device.name() {
                 if !devices.iter().any(|d| d.name == name) {

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -63,6 +63,13 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
 pub fn trigger_audio_permission() -> Result<bool> {
     use log::info;
 
+    // Serialize every alsa-lib call on Linux: see ALSA_GLOBAL_LOCK doc comment
+    // in devices/platform/linux.rs.
+    #[cfg(target_os = "linux")]
+    let _guard = platform::linux::ALSA_GLOBAL_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
     let host = cpal::default_host();
     let device = match host.default_input_device() {
         Some(d) => d,

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use log::error;
+use log::{error, info};
 
 use super::configuration::{AudioDevice, DeviceType};
 use super::platform;
 
 /// List all available audio devices on the system
 pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
+    info!("🎙️ list_audio_devices: start");
     let host = cpal::default_host();
 
     // Platform-specific device enumeration
@@ -18,7 +19,10 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
 
         #[cfg(target_os = "linux")]
         {
-            platform::configure_linux_audio(&host)?
+            info!("🎙️ list_audio_devices: calling configure_linux_audio");
+            let result = platform::configure_linux_audio(&host)?;
+            info!("🎙️ list_audio_devices: configure_linux_audio returned {} device(s)", result.len());
+            result
         }
 
         #[cfg(target_os = "macos")]
@@ -26,6 +30,7 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
             platform::configure_macos_audio(&host)?
         }
     };
+    info!("🎙️ list_audio_devices: platform enumeration done, {} device(s) so far", devices.len());
 
     // Add any additional devices from the default host
     if let Ok(other_devices) = host.devices() {

--- a/frontend/src-tauri/src/audio/devices/microphone.rs
+++ b/frontend/src-tauri/src/audio/devices/microphone.rs
@@ -4,8 +4,30 @@ use log::{info, warn};
 
 use super::configuration::{AudioDevice, DeviceType};
 
-/// Get the default input (microphone) device for the system
+/// Get the default input (microphone) device for the system.
+///
+/// On Linux, ask PulseAudio/PipeWire for the default source description so that
+/// "Default Microphone" points to the same item shown in the device list. Fall
+/// back to cpal's default input device if the server is unreachable.
 pub fn default_input_device() -> Result<AudioDevice> {
+    #[cfg(target_os = "linux")]
+    {
+        match crate::audio::capture::default_source_description() {
+            Ok(Some(description)) => {
+                return Ok(AudioDevice::new(description, DeviceType::Input));
+            }
+            Ok(None) => {
+                warn!("🎤 No default PulseAudio source reported, falling back to CPAL");
+            }
+            Err(e) => {
+                warn!(
+                    "🎤 Failed to query default PulseAudio source ({}), falling back to CPAL",
+                    e
+                );
+            }
+        }
+    }
+
     let host = cpal::default_host();
     let device = host
         .default_input_device()

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,9 +1,22 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
 use log::{info, warn};
+use std::sync::Mutex;
 
 use crate::audio::capture::list_pulse_sinks;
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
+
+/// alsa-lib's device/config enumeration (`snd_device_name_hint`,
+/// `snd_config_update_r`) is not safe to call concurrently from multiple
+/// threads: it mutates a process-global config cache. `list_audio_devices()`
+/// is polled every few seconds by the device disconnect/reconnect monitor
+/// (device_monitor.rs) while a recording is active, and can also be invoked
+/// at any time from the UI (device list refresh) or when starting a new
+/// recording (recording_manager.rs). Without serialization, an overlapping
+/// call from a second Tokio worker thread corrupts alsa-lib's heap state,
+/// which glibc eventually detects and aborts the process on — this is what
+/// produced the SIGABRT crashes after ~30 minutes of recording.
+pub(crate) static ALSA_ENUM_LOCK: Mutex<()> = Mutex::new(());
 
 /// Configure Linux audio devices. Microphones still go through cpal/ALSA
 /// (unaffected by this). System Audio entries come from PulseAudio/PipeWire's
@@ -13,8 +26,12 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
     info!("🎙️ configure_linux_audio: enumerating cpal/ALSA input devices");
-    // Add input devices
-    for device in host.input_devices()? {
+    // Serialize ALSA enumeration: see ALSA_ENUM_LOCK doc comment above.
+    let input_devices: Vec<_> = {
+        let _guard = ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        host.input_devices()?.collect()
+    };
+    for device in input_devices {
         if let Ok(name) = device.name() {
             devices.push(AudioDevice::new(name, DeviceType::Input));
         }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -3,7 +3,7 @@ use cpal::traits::{DeviceTrait, HostTrait};
 use log::{info, warn};
 use std::sync::Mutex;
 
-use crate::audio::capture::list_pulse_sinks;
+use crate::audio::capture::{list_pulse_sinks, list_pulse_sources};
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
 /// alsa-lib's device/config enumeration (`snd_device_name_hint`,
@@ -18,30 +18,83 @@ use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 /// produced the SIGABRT crashes after ~30 minutes of recording.
 pub(crate) static ALSA_ENUM_LOCK: Mutex<()> = Mutex::new(());
 
-/// Configure Linux audio devices. Microphones still go through cpal/ALSA
-/// (unaffected by this). System Audio entries come from PulseAudio/PipeWire's
-/// own sink list (real descriptions, no ~/.asoundrc monitor-hint scanning) —
-/// see audio/capture/pulse_linux.rs for the actual capture implementation.
+/// Degraded-mode filter: which raw cpal/ALSA PCM names are worth showing
+/// when the PulseAudio/PipeWire server can't be reached.
+///
+/// A whitelist is deliberately used instead of a blacklist: ALSA exposes many
+/// plugins, rate converters, and user-defined aliases (~/.asoundrc) that all
+/// look like plausible devices. Blacklisting them is endless and still leaves
+/// the list confusing. The whitelist gives a bounded, predictable fallback.
+pub(crate) fn is_useful_alsa_endpoint(name: &str) -> bool {
+    matches!(name.to_lowercase().as_str(), "default" | "pipewire" | "pulse")
+}
+
+/// Configure Linux audio devices.
+///
+/// In the nominal case (PulseAudio/PipeWire server reachable) both the
+/// microphone list and the system-audio list come from the server's own
+/// introspection: real human-readable descriptions, no ~/.asoundrc monitor-hint
+/// scanning, and no cpal/ALSA enumeration at all. This is the only way to show
+/// the same labels as the desktop's native audio settings (KDE, GNOME…).
+///
+/// If the server is unreachable, fall back to a short whitelist of ALSA
+/// endpoints (`default`, `pipewire`, `pulse`) so the list is never empty.
+///
+/// See audio/capture/pulse_linux.rs for the actual capture implementation.
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
-    info!("🎙️ configure_linux_audio: enumerating cpal/ALSA input devices");
-    // Serialize ALSA enumeration: see ALSA_ENUM_LOCK doc comment above.
-    let input_devices: Vec<_> = {
-        let _guard = ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        host.input_devices()?.collect()
-    };
-    for device in input_devices {
-        if let Ok(name) = device.name() {
-            devices.push(AudioDevice::new(name, DeviceType::Input));
+    // ------------------------------------------------------------------
+    // Microphones — nominal path: real PulseAudio/PipeWire input sources.
+    // ------------------------------------------------------------------
+    match list_pulse_sources() {
+        Ok(sources) => {
+            info!(
+                "🎙️ configure_linux_audio: PulseAudio/PipeWire gave {} input source(s)",
+                sources.len()
+            );
+            for source in sources {
+                devices.push(AudioDevice::new(source.description, DeviceType::Input));
+            }
+        }
+        Err(e) => {
+            warn!(
+                "🎙️ configure_linux_audio: failed to list PulseAudio/PipeWire sources ({}); falling back to filtered ALSA endpoints",
+                e
+            );
+
+            // Serialize ALSA enumeration: see ALSA_ENUM_LOCK doc comment above.
+            let input_devices: Vec<_> = {
+                let _guard = ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+                host.input_devices()?.collect()
+            };
+
+            let mut kept_any = false;
+            for device in input_devices {
+                if let Ok(name) = device.name() {
+                    if is_useful_alsa_endpoint(&name) {
+                        devices.push(AudioDevice::new(name, DeviceType::Input));
+                        kept_any = true;
+                    }
+                }
+            }
+
+            if !kept_any {
+                warn!("🎙️ configure_linux_audio: no useful ALSA endpoint found; adding 'default' so the list is never empty");
+                devices.push(AudioDevice::new("default".to_string(), DeviceType::Input));
+            }
         }
     }
-    info!("🎙️ configure_linux_audio: cpal/ALSA gave {} input device(s), now listing Pulse sinks", devices.len());
 
-    // Add PulseAudio/PipeWire sinks as "System Audio" devices
+    // ------------------------------------------------------------------
+    // System Audio — unchanged from US-01: PulseAudio/PipeWire sinks.
+    // ------------------------------------------------------------------
     match list_pulse_sinks() {
         Ok(sinks) => {
-            info!("🎙️ configure_linux_audio: list_pulse_sinks returned {} sink(s)", sinks.len());
+            info!(
+                "🎙️ configure_linux_audio: list_pulse_sinks returned {} sink(s)",
+                sinks.len()
+            );
             for sink in sinks {
                 devices.push(AudioDevice::new(
                     format!("{} (System Audio)", sink.description),
@@ -55,4 +108,56 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     }
 
     Ok(devices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_useful_alsa_endpoint;
+
+    #[test]
+    fn test_is_useful_alsa_endpoint_keeps_whitelist() {
+        for name in ["default", "pipewire", "pulse", "DEFAULT", "PipeWire", "PULSE"] {
+            assert!(
+                is_useful_alsa_endpoint(name),
+                "'{}' should be kept as a useful ALSA endpoint",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_useful_alsa_endpoint_rejects_noise() {
+        let rejected = [
+            "null",
+            "lavrate",
+            "samplerate",
+            "speexrate",
+            "jack",
+            "oss",
+            "speex",
+            "upmix",
+            "vdownmix",
+            "usbstream:CARD=Generic",
+            "sysdefault:CARD=Generic_1",
+            "sysdefault:CARD=acppdmmach",
+            "sysdefault:CARD=J380",
+            "hw:0,0",
+            "plughw:0,0",
+            "front:CARD=Generic,DEV=0",
+            "surround21:CARD=Generic",
+            "iec958:CARD=Generic",
+            "hdmi:CARD=HDMI,DEV=0",
+            "dmix:CARD=Generic",
+            "dsnoop:CARD=Generic",
+            "Ryzen_HD_Audio_Controller_Speaker_monitor",
+        ];
+
+        for name in rejected {
+            assert!(
+                !is_useful_alsa_endpoint(name),
+                "'{}' should be rejected as ALSA noise",
+                name
+            );
+        }
+    }
 }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,31 +1,39 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
+use log::{info, warn};
 
+use crate::audio::capture::list_pulse_sinks;
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
-/// Configure Linux audio devices using ALSA/PulseAudio
+/// Configure Linux audio devices. Microphones still go through cpal/ALSA
+/// (unaffected by this). System Audio entries come from PulseAudio/PipeWire's
+/// own sink list (real descriptions, no ~/.asoundrc monitor-hint scanning) —
+/// see audio/capture/pulse_linux.rs for the actual capture implementation.
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
+    info!("🎙️ configure_linux_audio: enumerating cpal/ALSA input devices");
     // Add input devices
     for device in host.input_devices()? {
         if let Ok(name) = device.name() {
             devices.push(AudioDevice::new(name, DeviceType::Input));
         }
     }
+    info!("🎙️ configure_linux_audio: cpal/ALSA gave {} input device(s), now listing Pulse sinks", devices.len());
 
-    // Add PulseAudio monitor sources for system audio
-    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-        for device in pulse_host.input_devices()? {
-            if let Ok(name) = device.name() {
-                // Check if it's a monitor source
-                if name.contains("monitor") {
-                    devices.push(AudioDevice::new(
-                        format!("{} (System Audio)", name),
-                        DeviceType::Output
-                    ));
-                }
+    // Add PulseAudio/PipeWire sinks as "System Audio" devices
+    match list_pulse_sinks() {
+        Ok(sinks) => {
+            info!("🎙️ configure_linux_audio: list_pulse_sinks returned {} sink(s)", sinks.len());
+            for sink in sinks {
+                devices.push(AudioDevice::new(
+                    format!("{} (System Audio)", sink.description),
+                    DeviceType::Output,
+                ));
             }
+        }
+        Err(e) => {
+            warn!("Failed to list PulseAudio/PipeWire sinks for System Audio: {}", e);
         }
     }
 

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -6,17 +6,21 @@ use std::sync::Mutex;
 use crate::audio::capture::{list_pulse_sinks, list_pulse_sources};
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
-/// alsa-lib's device/config enumeration (`snd_device_name_hint`,
-/// `snd_config_update_r`) is not safe to call concurrently from multiple
-/// threads: it mutates a process-global config cache. `list_audio_devices()`
-/// is polled every few seconds by the device disconnect/reconnect monitor
-/// (device_monitor.rs) while a recording is active, and can also be invoked
-/// at any time from the UI (device list refresh) or when starting a new
-/// recording (recording_manager.rs). Without serialization, an overlapping
-/// call from a second Tokio worker thread corrupts alsa-lib's heap state,
-/// which glibc eventually detects and aborts the process on — this is what
-/// produced the SIGABRT crashes after ~30 minutes of recording.
-pub(crate) static ALSA_ENUM_LOCK: Mutex<()> = Mutex::new(());
+/// Global lock serializing every interaction with alsa-lib on Linux.
+///
+/// alsa-lib's config/cache functions (`snd_device_name_hint`,
+/// `snd_config_update_r`) and PCM open functions (`snd_pcm_open`, called
+/// internally by `default_input_config`/`default_output_config`/
+/// `build_input_stream`) all mutate a process-global config cache and are not
+/// safe to call concurrently from multiple threads. `list_audio_devices()` is
+/// polled every few seconds by the device disconnect/reconnect monitor
+/// (device_monitor.rs) while a recording is active, and PCM setup happens on
+/// another Tokio worker thread whenever a cpal fallback stream starts
+/// (degraded mode, stale saved preference, permission trigger, etc.). Without
+/// serialization, an overlapping call corrupts alsa-lib's heap state, which
+/// glibc eventually detects and aborts the process on — this is what produced
+/// the SIGABRT crashes after ~30 minutes of recording.
+pub(crate) static ALSA_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Degraded-mode filter: which raw cpal/ALSA PCM names are worth showing
 /// when the PulseAudio/PipeWire server can't be reached.
@@ -63,9 +67,9 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
                 e
             );
 
-            // Serialize ALSA enumeration: see ALSA_ENUM_LOCK doc comment above.
+            // Serialize every alsa-lib call: see ALSA_GLOBAL_LOCK doc comment above.
             let input_devices: Vec<_> = {
-                let _guard = ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+                let _guard = ALSA_GLOBAL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
                 host.input_devices()?.collect()
             };
 

--- a/frontend/src-tauri/src/audio/devices/speakers.rs
+++ b/frontend/src-tauri/src/audio/devices/speakers.rs
@@ -35,7 +35,25 @@ pub fn default_output_device() -> Result<AudioDevice> {
         return Ok(AudioDevice::new(device.name()?, DeviceType::Output));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    {
+        // System audio on Linux is captured natively via PulseAudio/PipeWire
+        // (see audio/capture/pulse_linux.rs), not via cpal's ALSA host, so the
+        // "default" device must be one of the real Pulse sinks, decorated the
+        // same way configure_linux_audio() lists them.
+        let sinks = crate::audio::capture::list_pulse_sinks()
+            .map_err(|e| anyhow!("Failed to list PulseAudio/PipeWire sinks: {}", e))?;
+        let sink = sinks
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("No PulseAudio/PipeWire sink found"))?;
+        return Ok(AudioDevice::new(
+            format!("{} (System Audio)", sink.description),
+            DeviceType::Output,
+        ));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let host = cpal::default_host();
         let device = host

--- a/frontend/src-tauri/src/audio/playback_monitor.rs
+++ b/frontend/src-tauri/src/audio/playback_monitor.rs
@@ -121,15 +121,24 @@ async fn get_windows_output() -> Result<AudioOutputInfo> {
 async fn get_linux_output() -> Result<AudioOutputInfo> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
-    let host = cpal::default_host();
-    let device = host.default_output_device()
-        .ok_or_else(|| anyhow::anyhow!("No default output device found"))?;
+    // Serialize every alsa-lib call: see ALSA_GLOBAL_LOCK doc comment in
+    // devices/platform/linux.rs. The rest of the function (string heuristics)
+    // does not touch alsa-lib and can run unlocked.
+    let (device_name, sample_rate) = {
+        let _guard = crate::audio::devices::platform::linux::ALSA_GLOBAL_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
-    let device_name = device.name().unwrap_or_else(|_| "Unknown".to_string());
+        let host = cpal::default_host();
+        let device = host.default_output_device()
+            .ok_or_else(|| anyhow::anyhow!("No default output device found"))?;
 
-    let sample_rate = device.default_output_config()
-        .ok()
-        .map(|config| config.sample_rate().0);
+        let name = device.name().unwrap_or_else(|_| "Unknown".to_string());
+        let rate = device.default_output_config()
+            .ok()
+            .map(|config| config.sample_rate().0);
+        (name, rate)
+    };
 
     // Linux Bluetooth detection (PulseAudio/PipeWire naming)
     let name_lower = device_name.to_lowercase();

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -1559,27 +1559,24 @@ pub async fn attempt_device_reconnect(
         _ => return Err(format!("Invalid device type: {}", device_type)),
     };
 
-    // Check if recording is active
-    {
-        let manager_guard = RECORDING_MANAGER.lock().unwrap();
-        if manager_guard.is_none() {
-            return Err("Recording not active".to_string());
-        }
-    } // Release lock
+    // Take the manager out of the global mutex before the reconnection work,
+    // instead of holding the lock across the .await below. Since TECH-01,
+    // stream shutdown inside attempt_device_reconnect() is async and can take
+    // up to a few seconds (bounded join of the capture thread) instead of the
+    // near-instant sync call it used to be — holding a std::sync::Mutex across
+    // that would block every other command that locks RECORDING_MANAGER
+    // (stop_recording, status queries, ...) for the same duration. Same
+    // take()/put-back pattern as stop_recording() above.
+    let mut manager = match RECORDING_MANAGER.lock().unwrap().take() {
+        Some(m) => m,
+        None => return Err("Recording not active".to_string()),
+    };
 
-    // Spawn blocking task to handle the async reconnection
-    let result = tokio::task::spawn_blocking(move || {
-        tokio::runtime::Handle::current().block_on(async {
-            let mut manager_guard = RECORDING_MANAGER.lock().unwrap();
-            if let Some(manager) = manager_guard.as_mut() {
-                manager.attempt_device_reconnect(&device_name, monitor_type).await
-            } else {
-                Err(anyhow::anyhow!("Recording not active"))
-            }
-        })
-    })
-    .await
-    .map_err(|e| format!("Task join error: {}", e))?;
+    let result = manager.attempt_device_reconnect(&device_name, monitor_type).await;
+
+    // Put it back regardless of outcome — a failed reconnect attempt doesn't
+    // mean recording stopped.
+    *RECORDING_MANAGER.lock().unwrap() = Some(manager);
 
     match result {
         Ok(success) => {

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -240,7 +240,7 @@ impl RecordingManager {
         self.state.stop_recording();
 
         // Stop audio streams
-        if let Err(e) = self.stream_manager.stop_streams() {
+        if let Err(e) = self.stream_manager.stop_streams().await {
             error!("Error stopping audio streams: {}", e);
         }
 
@@ -269,7 +269,7 @@ impl RecordingManager {
         self.state.stop_recording();
 
         // Stop audio streams immediately
-        if let Err(e) = self.stream_manager.stop_streams() {
+        if let Err(e) = self.stream_manager.stop_streams().await {
             error!("Error stopping audio streams: {}", e);
             errors.push(format!("Failed to stop audio streams: {}", e));
         }
@@ -331,7 +331,7 @@ impl RecordingManager {
         self.state.stop_recording();
 
         // Stop audio streams
-        if let Err(e) = self.stream_manager.stop_streams() {
+        if let Err(e) = self.stream_manager.stop_streams().await {
             error!("Error stopping audio streams: {}", e);
         }
 
@@ -484,7 +484,7 @@ impl RecordingManager {
             self.state.stop_recording();
 
             // Stop audio streams
-            if let Err(e) = self.stream_manager.stop_streams() {
+            if let Err(e) = self.stream_manager.stop_streams().await {
                 error!("Error stopping audio streams during cleanup: {}", e);
             }
 
@@ -537,7 +537,7 @@ impl RecordingManager {
                     let system_device = self.state.get_system_device();
 
                     // Restart streams with new microphone
-                    self.stream_manager.stop_streams()?;
+                    self.stream_manager.stop_streams().await?;
                     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
                     self.stream_manager.start_streams(Some(device_arc.clone()), system_device, None).await?;
@@ -551,7 +551,7 @@ impl RecordingManager {
                     let microphone_device = self.state.get_microphone_device();
 
                     // Restart streams with new system audio
-                    self.stream_manager.stop_streams()?;
+                    self.stream_manager.stop_streams().await?;
                     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
                     self.stream_manager.start_streams(microphone_device, Some(device_arc.clone()), None).await?;

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -16,7 +16,7 @@ use super::capture::CoreAudioCapture;
 use super::recording_state::AudioError;
 
 #[cfg(target_os = "linux")]
-use super::capture::{find_monitor_source_by_description, PulseSystemCapture};
+use super::capture::{find_monitor_source_by_description, find_source_by_description, PulseCapture};
 #[cfg(target_os = "linux")]
 use std::sync::atomic::AtomicBool;
 
@@ -74,8 +74,9 @@ impl AudioStream {
         info!("🎵 Stream: Creating audio stream for device: {} with backend: {:?}, device_type: {:?}",
               device.name, backend_type, device_type);
 
-        // For system audio devices, use the selected backend
-        // For microphone devices, always use CPAL
+        // For system audio devices, use the selected backend.
+        // For microphone devices, prefer CPAL, except on Linux where we first
+        // try the native PulseAudio/PipeWire source path (see below).
         #[cfg(target_os = "macos")]
         let use_core_audio = device_type == DeviceType::System
             && backend_type == AudioCaptureBackend::CoreAudio;
@@ -108,6 +109,29 @@ impl AudioStream {
         if device_type == DeviceType::System {
             info!("🎵 Stream: Using native PulseAudio/PipeWire backend for system audio");
             return Self::create_pulse_stream(device, state, device_type, recording_sender).await;
+        }
+
+        // Linux microphones come from the PulseAudio/PipeWire source list (real
+        // human-readable descriptions, see devices/platform/linux.rs). Fall back
+        // to CPAL when the name isn't a known Pulse source: stale saved
+        // preferences and degraded-mode (no Pulse server) entries must keep
+        // working.
+        #[cfg(target_os = "linux")]
+        if device_type == DeviceType::Microphone {
+            match Self::create_pulse_mic_stream(
+                device.clone(),
+                state.clone(),
+                device_type.clone(),
+                recording_sender.clone(),
+            )
+            .await
+            {
+                Ok(stream) => return Ok(stream),
+                Err(e) => warn!(
+                    "🎤 Stream: native PulseAudio mic path unavailable ({}), falling back to CPAL",
+                    e
+                ),
+            }
         }
 
         // Default path: use CPAL
@@ -312,7 +336,7 @@ impl AudioStream {
         let monitor_source_name = find_monitor_source_by_description(description)
             .map_err(|e| anyhow::anyhow!("Failed to resolve PulseAudio sink '{}': {}", description, e))?;
 
-        let capture_impl = PulseSystemCapture::new(&monitor_source_name)
+        let capture_impl = PulseCapture::new_system(&monitor_source_name)
             .map_err(|e| anyhow::anyhow!("Failed to open PulseAudio record stream: {}", e))?;
 
         let sample_rate = capture_impl.sample_rate();
@@ -337,6 +361,70 @@ impl AudioStream {
         });
 
         info!("✅ Stream: PulseAudio stream fully initialized for device: {}", device.name);
+
+        Ok(Self {
+            device: device.clone(),
+            backend: StreamBackend::Pulse {
+                should_stop,
+                task: Some(task),
+            },
+        })
+    }
+
+    /// Create a native PulseAudio/PipeWire microphone stream (Linux only)
+    #[cfg(target_os = "linux")]
+    async fn create_pulse_mic_stream(
+        device: Arc<AudioDevice>,
+        state: Arc<RecordingState>,
+        device_type: DeviceType,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+    ) -> Result<Self> {
+        info!(
+            "🔊 Stream: Creating PulseAudio microphone stream for device: {}",
+            device.name
+        );
+
+        // Microphone names are stored as the PulseAudio source description.
+        // from_name() has already stripped the "(input)" suffix. If the
+        // description isn't known (stale saved preference or degraded-mode
+        // entry), this errors out and the caller falls back to CPAL.
+        let source_name = find_source_by_description(&device.name)
+            .map_err(|e| anyhow::anyhow!("Failed to resolve PulseAudio source '{}': {}", device.name, e))?;
+
+        let capture_impl = PulseCapture::new_microphone(&source_name)
+            .map_err(|e| anyhow::anyhow!("Failed to open PulseAudio record stream: {}", e))?;
+
+        let sample_rate = capture_impl.sample_rate();
+        let channels = capture_impl.channels();
+        let should_stop = capture_impl.stop_handle();
+
+        // Create audio capture processor for pipeline integration
+        let capture = AudioCapture::new(
+            device.clone(),
+            state.clone(),
+            sample_rate,
+            channels,
+            device_type,
+            recording_sender,
+        );
+
+        let device_name = device.name.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            info!(
+                "✅ Stream: PulseAudio microphone capture thread started for {}",
+                device_name
+            );
+            capture_impl.run(|samples| capture.process_audio_data(samples));
+            info!(
+                "⚠️ Stream: PulseAudio microphone capture thread ended for {}",
+                device_name
+            );
+        });
+
+        info!(
+            "✅ Stream: PulseAudio microphone stream fully initialized for device: {}",
+            device.name
+        );
 
         Ok(Self {
             device: device.clone(),

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -15,6 +15,11 @@ use super::capture::CoreAudioCapture;
 #[cfg(target_os = "macos")]
 use super::recording_state::AudioError;
 
+#[cfg(target_os = "linux")]
+use super::capture::{find_monitor_source_by_description, PulseSystemCapture};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::AtomicBool;
+
 /// Stream backend implementation
 pub enum StreamBackend {
     /// CPAL-based stream (ScreenCaptureKit or default)
@@ -22,6 +27,12 @@ pub enum StreamBackend {
     /// Core Audio direct implementation (macOS only)
     #[cfg(target_os = "macos")]
     CoreAudio {
+        task: Option<tokio::task::JoinHandle<()>>,
+    },
+    /// Native PipeWire/PulseAudio implementation (Linux only)
+    #[cfg(target_os = "linux")]
+    Pulse {
+        should_stop: Arc<AtomicBool>,
         task: Option<tokio::task::JoinHandle<()>>,
     },
 }
@@ -87,6 +98,16 @@ impl AudioStream {
         if use_core_audio {
             info!("🎵 Stream: Using Core Audio backend (cidre) for system audio");
             return Self::create_core_audio_stream(device, state, device_type, recording_sender).await;
+        }
+
+        // Linux system audio always goes through the native PipeWire/PulseAudio
+        // path instead of cpal's ALSA host — no backend toggle needed, unlike
+        // macOS's ScreenCaptureKit/CoreAudio choice, since there's only one way
+        // to capture system audio natively on Linux.
+        #[cfg(target_os = "linux")]
+        if device_type == DeviceType::System {
+            info!("🎵 Stream: Using native PulseAudio/PipeWire backend for system audio");
+            return Self::create_pulse_stream(device, state, device_type, recording_sender).await;
         }
 
         // Default path: use CPAL
@@ -270,6 +291,62 @@ impl AudioStream {
         })
     }
 
+    /// Create a native PulseAudio/PipeWire stream (Linux only)
+    #[cfg(target_os = "linux")]
+    async fn create_pulse_stream(
+        device: Arc<AudioDevice>,
+        state: Arc<RecordingState>,
+        device_type: DeviceType,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+    ) -> Result<Self> {
+        info!("🔊 Stream: Creating PulseAudio stream for device: {}", device.name);
+
+        // The picker shows "<sink description> (System Audio)" (see
+        // devices/platform/linux.rs); strip that suffix to recover the sink
+        // description and resolve it to its real monitor source name.
+        let description = device
+            .name
+            .strip_suffix(" (System Audio)")
+            .unwrap_or(&device.name);
+
+        let monitor_source_name = find_monitor_source_by_description(description)
+            .map_err(|e| anyhow::anyhow!("Failed to resolve PulseAudio sink '{}': {}", description, e))?;
+
+        let capture_impl = PulseSystemCapture::new(&monitor_source_name)
+            .map_err(|e| anyhow::anyhow!("Failed to open PulseAudio record stream: {}", e))?;
+
+        let sample_rate = capture_impl.sample_rate();
+        let channels = capture_impl.channels();
+        let should_stop = capture_impl.stop_handle();
+
+        // Create audio capture processor for pipeline integration
+        let capture = AudioCapture::new(
+            device.clone(),
+            state.clone(),
+            sample_rate,
+            channels,
+            device_type,
+            recording_sender,
+        );
+
+        let device_name = device.name.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            info!("✅ Stream: PulseAudio capture thread started for {}", device_name);
+            capture_impl.run(|samples| capture.process_audio_data(samples));
+            info!("⚠️ Stream: PulseAudio capture thread ended for {}", device_name);
+        });
+
+        info!("✅ Stream: PulseAudio stream fully initialized for device: {}", device.name);
+
+        Ok(Self {
+            device: device.clone(),
+            backend: StreamBackend::Pulse {
+                should_stop,
+                task: Some(task),
+            },
+        })
+    }
+
     /// Build stream based on sample format
     fn build_stream(
         device: &Device,
@@ -379,6 +456,20 @@ impl AudioStream {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     info!("Core Audio task aborted");
                 }
+            }
+            #[cfg(target_os = "linux")]
+            StreamBackend::Pulse { should_stop, task } => {
+                // Signal the blocking capture thread to stop after its current
+                // read() call returns, then give it a moment to actually exit.
+                // Unlike CoreAudio's tokio task, abort() can't preempt a thread
+                // blocked in a foreign blocking call, so the flag is what matters.
+                info!("Stopping PulseAudio capture thread...");
+                should_stop.store(true, std::sync::atomic::Ordering::Release);
+                if let Some(task_handle) = task {
+                    task_handle.abort();
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                info!("PulseAudio capture thread stopped");
             }
         }
 

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -518,8 +518,25 @@ impl AudioStream {
         &self.device
     }
 
-    /// Stop the stream
-    pub fn stop(self) -> Result<()> {
+    /// Signal the capture thread to stop, without waiting for it to exit.
+    ///
+    /// Used only by `AudioStreamManager::Drop`, which cannot be async. Every
+    /// normal shutdown path must use `stop().await` instead.
+    pub fn signal_stop_only(&self) {
+        match &self.backend {
+            #[cfg(target_os = "linux")]
+            StreamBackend::Pulse { should_stop, .. } => {
+                should_stop.store(true, std::sync::atomic::Ordering::Release);
+            }
+            _ => {
+                // CPAL/CoreAudio backends clean themselves up through their own
+                // Drop implementations; no explicit signal is needed here.
+            }
+        }
+    }
+
+    /// Stop the stream and wait for its capture thread/task to finish.
+    pub async fn stop(self) -> Result<()> {
         info!("Stopping audio stream for device: {}", self.device.name);
 
         match self.backend {
@@ -548,16 +565,26 @@ impl AudioStream {
             #[cfg(target_os = "linux")]
             StreamBackend::Pulse { should_stop, task } => {
                 // Signal the blocking capture thread to stop after its current
-                // read() call returns, then give it a moment to actually exit.
-                // Unlike CoreAudio's tokio task, abort() can't preempt a thread
-                // blocked in a foreign blocking call, so the flag is what matters.
-                info!("Stopping PulseAudio capture thread...");
+                // read() call returns, then await its JoinHandle with a bounded
+                // timeout. abort() on a spawn_blocking task that has already
+                // started is a no-op, so waiting is the only reliable way to
+                // know the thread has actually exited.
+                info!("Signalling PulseAudio capture thread to stop...");
                 should_stop.store(true, std::sync::atomic::Ordering::Release);
                 if let Some(task_handle) = task {
-                    task_handle.abort();
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(2),
+                        task_handle,
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => info!("PulseAudio capture thread joined cleanly"),
+                        Ok(Err(e)) => warn!("PulseAudio capture thread panicked: {}", e),
+                        Err(_) => warn!(
+                            "PulseAudio capture thread did not stop within 2s, abandoning join (thread may still be running)"
+                        ),
+                    }
                 }
-                info!("PulseAudio capture thread stopped");
             }
         }
 
@@ -647,15 +674,15 @@ impl AudioStreamManager {
         Ok(())
     }
 
-    /// Stop all audio streams
-    pub fn stop_streams(&mut self) -> Result<()> {
+    /// Stop all audio streams and wait for each capture thread to finish.
+    pub async fn stop_streams(&mut self) -> Result<()> {
         info!("Stopping all audio streams");
 
         let mut errors = Vec::new();
 
         // Stop microphone stream
         if let Some(mic_stream) = self.microphone_stream.take() {
-            if let Err(e) = mic_stream.stop() {
+            if let Err(e) = mic_stream.stop().await {
                 error!("Failed to stop microphone stream: {}", e);
                 errors.push(e);
             }
@@ -663,7 +690,7 @@ impl AudioStreamManager {
 
         // Stop system stream
         if let Some(sys_stream) = self.system_stream.take() {
-            if let Err(e) = sys_stream.stop() {
+            if let Err(e) = sys_stream.stop().await {
                 error!("Failed to stop system stream: {}", e);
                 errors.push(e);
             }
@@ -697,8 +724,16 @@ impl AudioStreamManager {
 
 impl Drop for AudioStreamManager {
     fn drop(&mut self) {
-        if let Err(e) = self.stop_streams() {
-            error!("Error stopping streams during drop: {}", e);
+        // Drop can't be async, so this is a best-effort signal-only shutdown —
+        // it does not wait for capture threads to actually exit. The real,
+        // awaited shutdown always happens via an explicit stop_streams().await
+        // earlier in every control-flow path (recording_manager.rs); this is
+        // only a safety net for paths that drop the manager without calling it.
+        if let Some(mic_stream) = self.microphone_stream.take() {
+            mic_stream.signal_stop_only();
+        }
+        if let Some(sys_stream) = self.system_stream.take() {
+            sys_stream.signal_stop_only();
         }
     }
 }

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -325,13 +325,14 @@ impl AudioStream {
     ) -> Result<Self> {
         info!("🔊 Stream: Creating PulseAudio stream for device: {}", device.name);
 
-        // The picker shows "<sink description> (System Audio)" (see
-        // devices/platform/linux.rs); strip that suffix to recover the sink
+        // The picker shows "<sink description> (System Audio) (output)" (see
+        // devices/platform/linux.rs); strip those suffixes to recover the sink
         // description and resolve it to its real monitor source name.
-        let description = device
+        let mut description = device
             .name
             .strip_suffix(" (System Audio)")
             .unwrap_or(&device.name);
+        description = description.strip_suffix(" (output)").unwrap_or(description);
 
         let monitor_source_name = find_monitor_source_by_description(description)
             .map_err(|e| anyhow::anyhow!("Failed to resolve PulseAudio sink '{}': {}", description, e))?;
@@ -354,10 +355,18 @@ impl AudioStream {
         );
 
         let device_name = device.name.clone();
+        let task = std::thread::Builder::new()
+            .name(format!("audio-capture-{}", device.name))
+            .spawn(move || {
+                info!("✅ Stream: PulseAudio capture thread started for {}", device_name);
+                capture_impl.run(|samples| capture.process_audio_data(samples));
+                info!("⚠️ Stream: PulseAudio capture thread ended for {}", device_name);
+            })
+            .map_err(|e| anyhow::anyhow!("Failed to spawn audio capture thread: {}", e))?;
+
+        // Wrap the thread handle in a tokio JoinHandle-like structure
         let task = tokio::task::spawn_blocking(move || {
-            info!("✅ Stream: PulseAudio capture thread started for {}", device_name);
-            capture_impl.run(|samples| capture.process_audio_data(samples));
-            info!("⚠️ Stream: PulseAudio capture thread ended for {}", device_name);
+            let _ = task.join();
         });
 
         info!("✅ Stream: PulseAudio stream fully initialized for device: {}", device.name);


### PR DESCRIPTION
### Attribution

Five of the six commits are authored by @loicfavory, from the native PipeWire/PulseAudio work referenced as PR #710 in the commit history. I've preserved the original authorship rather than squashing. The sixth commit (buffer tuning and device-name resolution) is mine.

# Native PipeWire/PulseAudio audio capture on Linux

## Summary

On Linux, System Audio capture currently only works if the user manually exposes a PipeWire/PulseAudio monitor source as a named ALSA pseudo-device. cpal, the audio library Meetily uses, has no native PulseAudio/PipeWire backend — only ALSA and JACK — so capturing "what's playing" requires a hand-written `~/.asoundrc` entry with `type pulse`, a `hint { show on }` block, and a PCM name that happens to contain the substring `monitor`, because that substring is what the Linux device filter keys on. Without that setup — that is, on any stock Linux install — the Settings → System Audio dropdown is simply empty.

This branch replaces that hack with a native `libpulse` client. System Audio entries now list real PulseAudio/PipeWire sinks directly, microphones are enumerated with the same human-readable descriptions that KDE and GNOME show, and capture streams through a dedicated Pulse backend instead of cpal's ALSA host. No per-machine setup is required.

It also carries three stability fixes found while building and reviewing the above, the most significant being a fix for a reproducible mid-recording crash.

## Background: the SIGABRT crash

`alsa-lib`'s `snd_device_name_hint` / `snd_config_update_r` mutate a process-global config cache and are not safe to call concurrently. `list_audio_devices()` is polled every 2–5s by the device disconnect/reconnect monitor for the entire duration of a recording, and can also be triggered from the UI or from `recording_manager` at any time. An overlapping call from a second Tokio worker thread corrupts alsa-lib's heap state, which glibc eventually detects and aborts on. This produced SIGABRT crashes roughly 30–35 minutes into a recording — two coredumps, both inside alsa-lib/malloc, both after that consistent delay. A process-wide mutex (`ALSA_GLOBAL_LOCK`) now serializes every alsa-lib interaction: enumeration, PCM open, and config.

## What changed

- **Native Pulse backend** (`audio/capture/pulse_linux.rs`, new): enumerates sinks and sources, resolves monitor sources by description, and streams capture for both the system and microphone channels.
- **Friendly device names**: Linux microphones are enumerated from PulseAudio/PipeWire sources with an ALSA whitelist fallback; `Default Microphone` resolves via the server's default-source description. The `host.devices()` fallback is disabled on Linux so raw ALSA PCM names stop leaking into the System Audio picker.
- **ALSA concurrency**: `ALSA_GLOBAL_LOCK` covers all remaining cpal/ALSA call sites — `get_device_and_config()` (both branches), `trigger_audio_permission()`, `get_linux_output()`, and the `list_system_devices()` / `check_system_audio_permissions()` commands. Its scope in `trigger_audio_permission()` is deliberately narrowed to exclude `play()`/`sleep()`/`drop()`, none of which touch the global config cache.
- **Reliable shutdown**: `AudioStream::stop()` and `AudioStreamManager::stop_streams()` are now `async` and await the Pulse capture thread with a 2s bounded timeout, replacing an `abort()` + `sleep(100ms)` that did not actually join anything. `signal_stop_only()` is added for best-effort shutdown from `Drop`, which cannot be async. The Pulse capture loop re-checks `should_stop` after `read()` returns so a late read cannot emit a stale chunk into a torn-down pipeline.
- **Lock held across await**: `attempt_device_reconnect` no longer holds the `RECORDING_MANAGER` `std::sync::Mutex` across its `.await`, which the shutdown change above made able to take up to ~4s. It uses the same `take()`/put-back pattern as `stop_recording()`, and the now-pointless `spawn_blocking` + `block_on` wrapper is gone.
- **Audio quality**: Pulse buffer attributes are tuned (1024-frame fragsize, 500ms maxlength) and capture runs on dedicated threads rather than the Tokio pool, fixing choppy audio when transcription competes for CPU. Sink existence is validated before capture, and the `(System Audio)` / `(output)` suffixes are stripped correctly when resolving a device name from saved preferences.

## Platform impact

Effectively all of the behavior change is behind `#[cfg(target_os = "linux")]`. The one cross-platform change is that `AudioStream::stop()` and `AudioStreamManager::stop_streams()` became `async`; all six `recording_manager` call sites are updated to await them. macOS and Windows capture paths are otherwise untouched.

## New dependencies

`libpulse-binding` 2.30.1 and `libpulse-simple-binding` 2.29.0, both declared only under `[target.'cfg(target_os = "linux")'.dependencies]`. They link against the system `libpulse`, which is present on any PipeWire or PulseAudio desktop; Linux builds need the `libpulse` development headers (`libpulse-dev` on Debian/Ubuntu, `libpulse` on Arch).

## Testing

Two pure unit tests cover the ALSA endpoint whitelist filter and run in CI normally. Three tests exercising a live server (`test_list_sinks`, `test_list_sources`, `test_capture_reads_nonzero_samples`) are marked `#[ignore]`, since they need a running PulseAudio/PipeWire server and, for the last one, real playback.

`cargo check` passes cleanly on this branch, and `cargo test --lib` reports 283 passed / 1 failed / 5 ignored. The single failure is `audio::device_detection::tests::test_calculate_buffer_timeout_bluetooth`, which is **pre-existing and unrelated** — `device_detection.rs` is untouched by this branch, and the test fails identically on `main` at v0.2.12.

Manual verification was done on a PipeWire desktop: sinks and sources appear with the same names the desktop's own audio settings show, System Audio capture records without any `~/.asoundrc` entry, and the previously reproducible ~30-minute SIGABRT no longer occurs.

Note for anyone building on a bleeding-edge toolchain: `whisper-rs-sys 0.11.1` uses bindgen 0.69.5, which emits `whisper_full_params` as an opaque type against libclang 22, producing 71 spurious `E0609` errors. This is a host toolchain artifact, not a repo problem. Build with `WHISPER_DONT_GENERATE_BINDINGS=1`, which the crate provides to use its vendored bindings.

## Review notes

- `ALSA_GLOBAL_LOCK` is process-wide and is now taken on every ALSA path, including device enumeration during recording. The lock scope was deliberately kept narrow around genuine alsa-lib calls; it is worth a look that no long-running operation slipped inside it.
- The 2s join timeout on Pulse capture-thread shutdown is a bounded fallback, not an expected path — a thread that hits it indicates the capture loop missed a stop signal.
- CHANGELOG.md is maintained by the release-preparation commits rather than per-PR, so no entry is included here.
