### PR TITLE
Fix blank device pickers and unreadable dropdowns in dark mode

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -218,6 +218,12 @@
    <html class="dark"> switches the same surfaces to the deep-navy skin.
    ============================================================ */
 :root {
+  /* Tell the engine which scheme native controls should paint in. Without this,
+     WebKitGTK renders <select>, its option popup, scrollbars and date pickers
+     with the light system theme regardless of our tokens — which left the
+     selected value in a <select> unreadable once the app was in dark mode. */
+  color-scheme: light;
+
   --af-bg: #f6f8fb;
   --af-panel: #ffffff;
   --af-panel-2: #eef3f8;
@@ -243,6 +249,9 @@
 }
 
 html.dark {
+  /* Repaint native controls dark too — see the note on :root. */
+  color-scheme: dark;
+
   /* Elevation ramp. Each step is a deliberate, small lift — enough to read as
      a distinct layer without the surfaces looking striped. */
   --af-bg: #0a0c10;       /* app canvas — near-black with a cool cast */

--- a/frontend/src/components/DeviceSelection.tsx
+++ b/frontend/src/components/DeviceSelection.tsx
@@ -32,6 +32,32 @@ export interface AudioLevelUpdate {
   levels: AudioLevelData[];
 }
 
+/** The option value a device renders as, and the string persisted in preferences. */
+export const toDeviceOptionValue = (d: AudioDevice) =>
+  `${d.name} (${d.device_type.toLowerCase()})`;
+
+/**
+ * Value a device <Select> should display for a saved preference.
+ *
+ * A saved string matching no <SelectItem> makes Radix render a BLANK trigger:
+ * the placeholder only shows for '' or undefined, and a stale preference is
+ * neither. Falling back to the 'default' sentinel keeps the picker readable and
+ * mirrors what the backend already does at record time, where an unresolvable
+ * device falls back to the system default.
+ *
+ * Display-only on purpose — it never writes, so the saved preference survives a
+ * device being temporarily absent and returns when the device does.
+ */
+export function deviceSelectValue(saved: string | null, available: string[]): string {
+  if (!saved) return 'default';
+  return available.includes(saved) ? saved : 'default';
+}
+
+/** "JBL Tune 770NC (System Audio) (output)" -> "JBL Tune 770NC (System Audio)" */
+export function deviceDisplayName(stored: string): string {
+  return stored.replace(/\s*\((input|output)\)$/i, '');
+}
+
 interface DeviceSelectionProps {
   selectedDevices: SelectedDevices;
   onDeviceChange: (devices: SelectedDevices) => void;
@@ -47,10 +73,29 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
   const [audioLevels, setAudioLevels] = useState<Map<string, AudioLevelData>>(new Map());
   const [isMonitoring, setIsMonitoring] = useState(false);
   const [showLevels, setShowLevels] = useState(false);
+  // One-way latch: a failed *refresh* leaves the last good list in place, so
+  // trust must never be downgraded once established.
+  const [hasLoadedDevices, setHasLoadedDevices] = useState(false);
 
   // Filter devices by type
   const inputDevices = devices.filter(device => device.device_type === 'Input');
   const outputDevices = devices.filter(device => device.device_type === 'Output');
+
+  // Single source of truth for the option values, shared by the <SelectItem>s
+  // and the reconciliation below — a mismatch between the two is the bug.
+  const micOptions = inputDevices.map(toDeviceOptionValue);
+  const systemOptions = outputDevices.map(toDeviceOptionValue);
+
+  // A saved device that isn't in the current list. Guarded on the per-list
+  // length because get_audio_devices can succeed while list_pulse_sinks() failed
+  // server-side, yielding Input entries and zero Output entries — in which case
+  // we genuinely don't know whether the device is missing.
+  const micFellBack =
+    hasLoadedDevices && micOptions.length > 0 &&
+    !!selectedDevices.micDevice && !micOptions.includes(selectedDevices.micDevice);
+  const systemFellBack =
+    !isMacOS && hasLoadedDevices && systemOptions.length > 0 &&
+    !!selectedDevices.systemDevice && !systemOptions.includes(selectedDevices.systemDevice);
 
   useEffect(() => {
     if (isMacOS && selectedDevices.systemDevice !== null) {
@@ -64,6 +109,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
       setError(null);
       const result = await invoke<AudioDevice[]>('get_audio_devices');
       setDevices(result);
+      setHasLoadedDevices(true);
       console.log('Fetched audio devices:', result);
     } catch (err) {
       console.error('Failed to fetch audio devices:', err);
@@ -275,7 +321,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
             </Label>
           </div>
           <Select
-            value={selectedDevices.micDevice || 'default'}
+            value={deviceSelectValue(selectedDevices.micDevice, micOptions)}
             onValueChange={handleMicDeviceChange}
             disabled={disabled}
           >
@@ -287,7 +333,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
               {inputDevices.map((device) => (
                 <SelectItem
                   key={device.name}
-                  value={`${device.name} (${device.device_type.toLowerCase()})`}
+                  value={toDeviceOptionValue(device)}
                 >
                   {device.name}
                 </SelectItem>
@@ -296,6 +342,12 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           </Select>
           {inputDevices.length === 0 && (
             <p className="text-xs text-gray-500">No microphone devices found</p>
+          )}
+          {micFellBack && (
+            <p className="text-xs text-amber-600">
+              “{deviceDisplayName(selectedDevices.micDevice!)}” isn’t available right now — using
+              the default microphone. It’ll be restored when the device reconnects.
+            </p>
           )}
 
           {/* Audio Level Meters for Input Devices */}
@@ -344,7 +396,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           </div>
 
           <Select
-            value={isMacOS ? 'default' : selectedDevices.systemDevice || 'default'}
+            value={isMacOS ? 'default' : deviceSelectValue(selectedDevices.systemDevice, systemOptions)}
             onValueChange={handleSystemDeviceChange}
             disabled={disabled || isMacOS}
           >
@@ -356,7 +408,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
               {!isMacOS && outputDevices.map((device) => (
                 <SelectItem
                   key={device.name}
-                  value={`${device.name} (${device.device_type.toLowerCase()})`}
+                  value={toDeviceOptionValue(device)}
                 >
                   {device.name}
                 </SelectItem>
@@ -366,6 +418,12 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
 
           {outputDevices.length === 0 && (
             <p className="text-xs text-gray-500">No system audio devices found</p>
+          )}
+          {systemFellBack && (
+            <p className="text-xs text-amber-600">
+              “{deviceDisplayName(selectedDevices.systemDevice!)}” isn’t available right now — using
+              the system default. It’ll be restored when the device reconnects.
+            </p>
           )}
           {isMacOS && outputDevices.length > 0 && (
             <p className="text-xs text-gray-500">

--- a/frontend/src/components/DeviceSelection.tsx
+++ b/frontend/src/components/DeviceSelection.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Label } from '@/components/ui/label';
 import Analytics from '@/lib/analytics';
 import { usePlatform } from '@/hooks/usePlatform';
+import { toDeviceOptionValue, deviceSelectValue, deviceDisplayName } from '@/lib/audio-devices';
 
 export interface AudioDevice {
   name: string;
@@ -30,32 +31,6 @@ export interface AudioLevelData {
 export interface AudioLevelUpdate {
   timestamp: number;
   levels: AudioLevelData[];
-}
-
-/** The option value a device renders as, and the string persisted in preferences. */
-export const toDeviceOptionValue = (d: AudioDevice) =>
-  `${d.name} (${d.device_type.toLowerCase()})`;
-
-/**
- * Value a device <Select> should display for a saved preference.
- *
- * A saved string matching no <SelectItem> makes Radix render a BLANK trigger:
- * the placeholder only shows for '' or undefined, and a stale preference is
- * neither. Falling back to the 'default' sentinel keeps the picker readable and
- * mirrors what the backend already does at record time, where an unresolvable
- * device falls back to the system default.
- *
- * Display-only on purpose — it never writes, so the saved preference survives a
- * device being temporarily absent and returns when the device does.
- */
-export function deviceSelectValue(saved: string | null, available: string[]): string {
-  if (!saved) return 'default';
-  return available.includes(saved) ? saved : 'default';
-}
-
-/** "JBL Tune 770NC (System Audio) (output)" -> "JBL Tune 770NC (System Audio)" */
-export function deviceDisplayName(stored: string): string {
-  return stored.replace(/\s*\((input|output)\)$/i, '');
 }
 
 interface DeviceSelectionProps {

--- a/frontend/src/lib/audio-devices.ts
+++ b/frontend/src/lib/audio-devices.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure helpers for reconciling a saved audio-device preference against the
+ * devices currently reported by the backend.
+ *
+ * Kept out of the component so they can be unit tested without React or Tauri.
+ */
+
+export interface AudioDeviceOption {
+  name: string;
+  device_type: 'Input' | 'Output';
+}
+
+/** The option value a device renders as, and the string persisted in preferences. */
+export const toDeviceOptionValue = (d: AudioDeviceOption) =>
+  `${d.name} (${d.device_type.toLowerCase()})`;
+
+/**
+ * Value a device <Select> should display for a saved preference.
+ *
+ * A saved string matching no <SelectItem> makes Radix render a BLANK trigger:
+ * the placeholder only shows for '' or undefined, and a stale preference is
+ * neither. Falling back to the 'default' sentinel keeps the picker readable and
+ * mirrors what the backend already does at record time, where an unresolvable
+ * device falls back to the system default.
+ *
+ * Display-only on purpose — it never writes, so the saved preference survives a
+ * device being temporarily absent and returns when the device does.
+ */
+export function deviceSelectValue(saved: string | null, available: string[]): string {
+  if (!saved) return 'default';
+  return available.includes(saved) ? saved : 'default';
+}
+
+/** "JBL Tune 770NC (System Audio) (output)" -> "JBL Tune 770NC (System Audio)" */
+export function deviceDisplayName(stored: string): string {
+  return stored.replace(/\s*\((input|output)\)$/i, '');
+}

--- a/frontend/tests/lib/audio-devices.test.ts
+++ b/frontend/tests/lib/audio-devices.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  deviceDisplayName,
+  deviceSelectValue,
+  toDeviceOptionValue,
+} from '../../src/lib/audio-devices';
+
+describe('toDeviceOptionValue', () => {
+  test('matches the string persisted in preferences', () => {
+    expect(toDeviceOptionValue({ name: 'USB Audio Headphones (System Audio)', device_type: 'Output' }))
+      .toBe('USB Audio Headphones (System Audio) (output)');
+  });
+
+  test('lowercases the device type', () => {
+    expect(toDeviceOptionValue({ name: 'Built-in Mic', device_type: 'Input' }))
+      .toBe('Built-in Mic (input)');
+  });
+});
+
+describe('deviceSelectValue', () => {
+  const available = ['Built-in Mic (input)', 'JBL Tune 770NC (input)'];
+
+  test('keeps a saved device that is still available', () => {
+    expect(deviceSelectValue('JBL Tune 770NC (input)', available)).toBe('JBL Tune 770NC (input)');
+  });
+
+  test('falls back to the default sentinel when the saved device is gone', () => {
+    // The disconnected-Bluetooth case: previously left the picker blank.
+    expect(deviceSelectValue('Disconnected Headset (input)', available)).toBe('default');
+  });
+
+  test('returns the default sentinel when nothing is saved', () => {
+    expect(deviceSelectValue(null, available)).toBe('default');
+  });
+
+  test('falls back while the device list is still empty', () => {
+    expect(deviceSelectValue('JBL Tune 770NC (input)', [])).toBe('default');
+  });
+
+  test('does not match on a partial name', () => {
+    expect(deviceSelectValue('JBL Tune 770NC', available)).toBe('default');
+  });
+});
+
+describe('deviceDisplayName', () => {
+  test('strips the output suffix', () => {
+    expect(deviceDisplayName('JBL Tune 770NC (System Audio) (output)'))
+      .toBe('JBL Tune 770NC (System Audio)');
+  });
+
+  test('strips the input suffix', () => {
+    expect(deviceDisplayName('Built-in Mic (input)')).toBe('Built-in Mic');
+  });
+
+  test('leaves a name with no suffix alone', () => {
+    expect(deviceDisplayName('Built-in Mic')).toBe('Built-in Mic');
+  });
+
+  test('only strips a trailing suffix, not one mid-name', () => {
+    expect(deviceDisplayName('Mic (input) Dock (output)')).toBe('Mic (input) Dock');
+  });
+});


### PR DESCRIPTION
# Fix blank device pickers and unreadable dropdowns in dark mode

Two independent UI bugs, both cross-platform, both frontend-only. No Rust changes.

## 1. A saved device that disappears leaves the picker blank

Select a device in Settings, then disconnect it — a Bluetooth headset is the easy way to reproduce — and the dropdown renders **empty** rather than falling back to anything readable.

`DeviceSelection` bound `value={selectedDevices.systemDevice || 'default'}`. When the saved device is gone that string matches no `<SelectItem>`, and Radix only shows its placeholder for `''` or `undefined` — a stale preference is neither, so the trigger paints blank. Nothing reconciled the value, so it stayed that way and kept being persisted. The microphone dropdown had the identical bug.

Worth noting the recording path was never broken: `recording_commands.rs` already falls back to `default_output_device()` when a preferred device won't resolve. This is purely what the user sees.

### The fix, and why it does not write

`deviceSelectValue()` is a **render-time projection that never writes**. A missing device displays as "Default", but the stored preference is untouched, so reconnecting the device restores the selection on its own.

That restraint is deliberate. There are several windows where the device list is empty or untrustworthy — the initial render before `get_audio_devices` resolves, the call throwing, a transient dropout, and on Linux the call succeeding while sink enumeration failed server-side, which yields input entries and zero output entries. A write-back reset could destroy a valid preference in any of them; a projection can at worst show the wrong label for one paint. The "unavailable" notice is additionally guarded on a per-list length check so it never claims a device is missing when we genuinely cannot tell.

Two further reasons write-back would be wrong in this component specifically: `onDeviceChange` means different things at its two mount points — `SettingsModal` passes `setSelectedDevices`, which never persists, while `RecordingSettings` passes `handleDeviceChange`, which persists *and* fires analytics — and `handleDeviceChange` is re-created every render, so any effect depending on it re-runs constantly. The existing macOS effect in this file already has that shape; I have left it alone but it is worth a look separately.

## 2. Native dropdowns are unreadable in dark mode

The app never declared `color-scheme`. Without it WebKitGTK paints native form controls with the light system theme regardless of the `--af-*` tokens, so a `<select>` drew a light native background while its text stayed faint — the selected value was effectively invisible once the app was in dark mode, with the option popup rendering white beneath a dark UI.

Fixed at the root with `color-scheme: light` on `:root` and `color-scheme: dark` on `html.dark`, rather than patching the one component where it happened to be noticed. **Five components use a native `<select>`** — `LanguageSelection`, `LiveAssistant`, `TemplateEditorModal`, `SettingsModal` and `AudioTestStep` — and all had the same defect. Native scrollbars and date pickers follow the theme now too.

Since `:root` gained an explicit declaration where it previously had none, the light theme is worth a glance while reviewing.

## Testing

The pure logic lives in `src/lib/audio-devices.ts` with 11 unit tests in `tests/lib/audio-devices.test.ts`, following the existing bun-test convention. They cover the cases that matter: a saved device that is gone falls back, nothing saved falls back, an empty device list falls back, a partial name does **not** match, and the display-name helper strips only a trailing `(input)`/`(output)` suffix.

Full suite: 22 pass, 0 fail across 5 files. `tsc --noEmit` clean apart from pre-existing `bun:test` module-resolution errors in `tests/lib`.

The React components have no automated coverage — there is no DOM testing library in the repo — so the dark mode fix in particular is a visual change that wants a look in both themes. For the picker, the manual check that matters is disconnect **and then reconnect** a device: the reconnect is what demonstrates the preference was never overwritten.
